### PR TITLE
FIX:close psd plotting window to prevent memory consumption

### DIFF
--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1813,3 +1813,4 @@ def plot_raw_psd(p, subjects, tmin=0., fmin=2, n_fft=2048):
                          n_jobs=p.n_jobs, proj=False, ax=None, color=(0, 0, 1),
                          picks=None)
             plt.savefig(fname[0][:-4] + '_psd.png')
+            plt.close()


### PR DESCRIPTION
@Eric89GXL I got a memory usage warning about too many open `pyplot` windows during psd plotting for a large group of subjects. This is the fastest way I know to make it go away. LMKWYT.