### PR TITLE
ENH: Add info SSS basis

### DIFF
--- a/mnefun/__init__.py
+++ b/mnefun/__init__.py
@@ -4,6 +4,7 @@ from ._paths import get_raw_fnames, get_event_fnames  # noqa
 from ._mnefun import (Params, get_fsaverage_medial_vertices,  # noqa
                       anova_time, safe_inserter,  # noqa
                       extract_expyfun_events, do_processing,  # noqa
-                      run_sss_command, run_sss_positions)  # noqa
+                      run_sss_command, run_sss_positions,  # noqa
+                      info_sss_basis)  # noqa
 
 __version__ = '0.1.0.dev0'


### PR DESCRIPTION
@kambysese can you have a look?

@mdclarke @staulu you should be able to do this:
```
import numpy as np
from scipy import linalg

import mne
from mnefun import info_sss_basis

data_path = mne.datasets.sample.data_path()
evoked = mne.read_evokeds(data_path + '/MEG/sample/sample_audvis-ave.fif')[0]
evoked = evoked.pick_types(meg=True)  # only look at MEG channels
S = info_sss_basis(evoked.info)
sing = linalg.svdvals(S)
print('Condition before proj:  %s' % (sing[0] / sing[-1],))
proj_op = mne.io.proj.make_projector_info(evoked.info)[0]
S_proj = np.dot(proj_op, S)
sing = linalg.svdvals(S_proj)
print('Condition after proj:   %s' % (sing[0] / sing[-1],))
```
And see:
```
Condition before proj:  59.0775421459
Condition after proj:   135.880057672
```