### PR TITLE
ENH: Add reconstruction

### DIFF
--- a/mnefun/__init__.py
+++ b/mnefun/__init__.py
@@ -5,6 +5,6 @@ from ._mnefun import (Params, get_fsaverage_medial_vertices,  # noqa
                       anova_time, safe_inserter,  # noqa
                       extract_expyfun_events, do_processing,  # noqa
                       run_sss_command, run_sss_positions,  # noqa
-                      info_sss_basis)  # noqa
+                      info_sss_basis, plot_reconstruction)  # noqa
 
 __version__ = '0.1.0.dev0'


### PR DESCRIPTION
cc @staulu @mdclarke on this branch you should be able to this:
```
import os.path as op

import mne
from mnefun import plot_reconstruction

data_path = mne.datasets.sample.data_path()
raw = mne.io.read_raw_fif(op.join(data_path, 'MEG', 'sample',
                          'sample_audvis_raw.fif'), preload=True)
raw.pick_types(meg=True, eeg=False, eog=True, stim=True, exclude=())
events = mne.find_events(raw, 'STI 014')
raw.add_proj(mne.preprocessing.compute_proj_eog(raw)[0])
raw.add_proj(mne.preprocessing.compute_proj_ecg(raw)[0])
epochs = mne.Epochs(raw, events, {'Left auditory': 1}, -0.2, 0.5,
                    baseline=(None, 0), proj='delayed',
                    reject=dict(grad=4000e-13, mag=4e-12, eog=150e-6))
evoked = epochs.average()

plot_reconstruction(evoked)
```
And obtain this:
![figure_1](https://cloud.githubusercontent.com/assets/2365790/14833263/5e7c764e-0bcc-11e6-8f00-a3d3d7679c48.png)

@mdclarke let me know if it works for you. I expect that we'll need to tweak e.g. the y-axis limits.