### PR TITLE
WIP:plot artifact SSP topographies and save.

### DIFF
--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -76,7 +76,9 @@ params.runs_empty = ['%s_erm']  # Define empty room runs
 params.proj_nums = [[1, 1, 0],  # ECG
                     [1, 1, 2],  # EOG
                     [0, 0, 0]]  # Continuous (from ERM)
-params.plot_pca = True  # Write PCA projection topography figures to disk
+# By default SSP projection scalp topography maps will be saved in
+# sss_pca_folder for inspection. To avoid having images saved to disk set
+# params.plot_pca = False
 params.cov_method = 'shrunk'  # Cleaner noise covariance regularization
 params.plot_head_position = True  # Plot cHPI data for single raw file
 # python | maxfilter for choosing SSS applied using either Maxfilter or MNE

--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -76,6 +76,7 @@ params.runs_empty = ['%s_erm']  # Define empty room runs
 params.proj_nums = [[1, 1, 0],  # ECG
                     [1, 1, 2],  # EOG
                     [0, 0, 0]]  # Continuous (from ERM)
+params.plot_pca = True  # Write PCA projection topography figures to disk
 params.cov_method = 'shrunk'  # Cleaner noise covariance regularization
 params.plot_head_position = True  # Plot cHPI data for single raw file
 # python | maxfilter for choosing SSS applied using either Maxfilter or MNE

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1925,6 +1925,9 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 print('    Adding extra projectors from "%s".' % p.proj_extra)
             extra_proj = op.join(pca_dir, p.proj_extra)
             projs = read_proj(extra_proj)
+            if p.plot_pca:
+                h = plot_projs_topomap(projs, info=raw_orig.info, show=False)
+                h.savefig(extra_proj[:-4] + '.png', format='png', dpi=120)
 
         # Calculate and apply ERM projectors
         proj_nums = np.array(proj_nums, int)
@@ -1958,6 +1961,9 @@ def do_preprocessing_combined(p, subjects, run_indices):
                                   reject=None, flat=None, n_jobs=p.n_jobs_mkl)
             write_proj(cont_proj, pr)
             projs.extend(pr)
+            if p.plot_pca:
+                h = plot_projs_topomap(pr, info=raw.info, show=False)
+                h.savefig(cont_proj[:-4] + '.png', format='png', dpi=120)
             del raw
 
         # Calculate and apply the ECG projectors

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -404,7 +404,7 @@ class Params(Frozen):
         self.must_match = []
         self.on_missing = 'error'  # for epochs
         self.subject_run_indices = None
-        self.plot_pca = False
+        self.plot_pca = True
         self.freeze()
 
     @property

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -71,7 +71,7 @@ from mne.io.pick import pick_types_forward, pick_types
 from mne.io.meas_info import _empty_info
 from mne.cov import regularize
 from mne.minimum_norm import write_inverse_operator
-from mne.viz import plot_drop_log, tight_layout
+from mne.viz import plot_drop_log, tight_layout, plot_projs_topomap
 from mne.viz._3d import plot_head_positions
 from mne.utils import run_subprocess
 from mne.report import Report
@@ -243,6 +243,9 @@ class Params(Frozen):
         Default is center of sphere fit to digitized head points.
     fir_design : str
         Can be "firwin2" or "firwin".
+    plot_pca : bool
+        If set to True generate selected PCA component topographies and save
+        figures to disk in pca_fif folder.
 
     Returns
     -------
@@ -401,6 +404,7 @@ class Params(Frozen):
         self.must_match = []
         self.on_missing = 'error'  # for epochs
         self.subject_run_indices = None
+        self.plot_pca = False
         self.freeze()
 
     @property
@@ -1984,6 +1988,9 @@ def do_preprocessing_combined(p, subjects, run_indices):
             else:
                 warnings.warn('Only %d ECG events!' % ecg_events.shape[0])
             del raw
+            if p.plot_pca:
+                h = plot_projs_topomap(pr, show=True)
+                h.savefig(ecg_proj[:-4] + '.png', format='png', dpi=120)
 
         # Next calculate and apply the EOG projectors
         if any(proj_nums[1]):
@@ -2012,6 +2019,10 @@ def do_preprocessing_combined(p, subjects, run_indices):
             else:
                 warnings.warn('Only %d EOG events!' % eog_events.shape[0])
             del raw
+            #TODO just plotting MEG topographies. EEG topographies need layout
+            if p.plot_pca:
+                h = plot_projs_topomap(pr[:2], show=True)
+                h.savefig(eog_proj[:-4] + '.png', format='png', dpi=120)
 
         # save the projectors
         write_proj(all_proj, projs)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1987,10 +1987,10 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 projs.extend(pr)
             else:
                 warnings.warn('Only %d ECG events!' % ecg_events.shape[0])
-            del raw
             if p.plot_pca:
-                h = plot_projs_topomap(pr, show=True)
+                h = plot_projs_topomap(pr, info=raw.info, show=False)
                 h.savefig(ecg_proj[:-4] + '.png', format='png', dpi=120)
+            del raw
 
         # Next calculate and apply the EOG projectors
         if any(proj_nums[1]):
@@ -2018,11 +2018,10 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 projs.extend(pr)
             else:
                 warnings.warn('Only %d EOG events!' % eog_events.shape[0])
-            del raw
-            #TODO just plotting MEG topographies. EEG topographies need layout
             if p.plot_pca:
-                h = plot_projs_topomap(pr[:2], show=True)
+                h = plot_projs_topomap(pr, info=raw.info, show=False)
                 h.savefig(eog_proj[:-4] + '.png', format='png', dpi=120)
+            del raw
 
         # save the projectors
         write_proj(all_proj, projs)


### PR DESCRIPTION
@larsoner currently this WIP plots SSP projection topographies of artifacts for MEG sensors and saves figure in `sss_pca_fif` directory. I have two questions:

1. Does `mne.viz.plot_projs_topomap` already handle multiple projection components across channel types e.g., if I request 2 SSP projectors for Grad and 1 projector for Mags will the program plot accordingly

2. How would you advise dealing with EEG projections? As is `mne.viz.plot_projs_topomap` returns a RT error because it cannot find appropriate EEG layout in funloc data. 

LMKWYT.