### PR TITLE
FIX: trans_to, subjects_dir, extract_expyfun_events

### DIFF
--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1709,8 +1709,9 @@ def gen_forwards(p, subjects, structurals, run_indices):
         raw_fname = get_raw_fnames(p, subj, 'sss', False, False,
                                    run_indices[si])[0]
         info = read_info(raw_fname)
+        struc = structurals[si]
 
-        if structurals[si] is None:  # spherical case
+        if struc is None:  # spherical case
             # create spherical BEM
             bem = make_sphere_model('auto', 'auto', info, verbose=False)
             # create source space
@@ -1727,16 +1728,19 @@ def gen_forwards(p, subjects, structurals, run_indices):
                                 subj + '-trans_head2mri.txt')
                 if not op.isfile(trans):
                     raise IOError('Unable to find head<->MRI trans file')
-            src_space_file = op.join(subjects_dir, structurals[si], 'bem',
-                                     structurals[si] + '-oct6-src.fif')
-            if not op.isfile(src_space_file):
+            for mid in ('oct6', 'oct-6'):
+                src_space_file = op.join(subjects_dir, struc, 'bem',
+                                         '%s-%s-src.fif' % (struc, mid))
+                if op.isfile(src_space_file):
+                    break
+            else:  # if neither exists, use last filename
                 print('  Creating source space for %s...' % subj)
-                src = setup_source_space(structurals[si], spacing='oct6',
+                src = setup_source_space(struc, spacing='oct6',
                                          n_jobs=p.n_jobs)
                 write_source_spaces(src_space_file, src)
             src = read_source_spaces(src_space_file)
-            bem = op.join(subjects_dir, structurals[si], 'bem',
-                          structurals[si] + '-' + p.bem_type + '-bem-sol.fif')
+            bem = op.join(subjects_dir, struc, 'bem', '%s-%s-bem-sol.fif'
+                          % (struc, p.bem_type))
             bem_type = ('%s-layer BEM' %
                         len(read_bem_solution(bem, verbose=False)['surfs']))
         if not getattr(p, 'translate_positions', True):

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1284,7 +1284,8 @@ def get_fsaverage_medial_vertices(concatenate=True):
 
 @verbose
 def get_fsaverage_label_operator(parc='aparc.a2009s', remove_bads=True,
-                                 combine_medial=False, verbose=None):
+                                 combine_medial=False, return_labels=False,
+                                 verbose=None):
     """Get a label operator matrix for fsaverage."""
     subjects_dir = mne.get_config('SUBJECTS_DIR')
     src = mne.read_source_spaces(op.join(
@@ -1317,7 +1318,10 @@ def get_fsaverage_label_operator(parc='aparc.a2009s', remove_bads=True,
     # assert (rev_op.sum(-1) == 1).sum()
     label_op = mne.SourceEstimate(np.eye(20484), fs_vertices, 0, 1)
     label_op = label_op.extract_label_time_course(labels, src)
-    return label_op, rev_op
+    out = (label_op, rev_op)
+    if return_labels:
+        out += (labels,)
+    return out
 
 
 @verbose


### PR DESCRIPTION
This PR:

1. Adds a fourth argument to the `trans_to` tuple, which is a forward(+)/backward(-) head rotation, e.g. `(0., 0., 0.04, -30)` will rotate the head backward 30 degrees.
2. Allows setting `subjects_dir` that will be used to find the structurals.
3. Fixes processing when `STI101` is the only trigger channel available. @mdclarke can you confirm this fixes #195 for you?

Closes #195.