### PR TITLE
ENH: Add projector averaging

### DIFF
--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -100,6 +100,8 @@ params.runs_empty = ['%s_erm']  # Define empty room runs
 params.proj_nums = [[1, 1, 0],  # ECG
                     [1, 1, 2],  # EOG
                     [0, 0, 0]]  # Continuous (from ERM)
+params.proj_ave = True  # better projections by averaging ECG/EOG epochs
+
 # Set to True to use Autoreject module to set global epoch rejection thresholds
 params.autoreject_thresholds = False
 # Set to ('meg', 'eeg', eog') to reject trials based on EOG

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -425,6 +425,7 @@ class Params(Frozen):
         self.coil_dist_limit = 0.005
         self.coil_t_window = 0.2  # default is same as MF
         self.coil_t_step_min = 0.01
+        self.proj_ave = False
         self.freeze()
 
     @property
@@ -2220,7 +2221,8 @@ def do_preprocessing_combined(p, subjects, run_indices):
                                  tmin=ecg_t_lims[0], tmax=ecg_t_lims[1],
                                  l_freq=None, h_freq=None, no_proj=True,
                                  qrs_threshold='auto', ch_name=p.ecg_channel,
-                                 reject=p.ssp_ecg_reject, return_drop_log=True)
+                                 reject=p.ssp_ecg_reject, return_drop_log=True,
+                                 average=p.proj_ave)
             n_good = sum(len(d) == 0 for d in drop_log)
             if n_good >= 20:
                 write_events(ecg_eve, ecg_events)
@@ -2252,7 +2254,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
                                  tmin=eog_t_lims[0], tmax=eog_t_lims[1],
                                  l_freq=None, h_freq=None, no_proj=True,
                                  ch_name=p.eog_channel,
-                                 reject=p.ssp_eog_reject)
+                                 reject=p.ssp_eog_reject, average=p.proj_ave)
             if eog_events.shape[0] >= 5:
                 write_events(eog_eve, eog_events)
                 write_proj(eog_proj, pr)


### PR DESCRIPTION
This adds an option to average epochs when computing EOG and ECG projectors. In some testing this seems to work a little bit better.

@ktavabi at some point you might want to try this on your data. In the meantime the default remains `False`, which is the same as it was before.