### PR TITLE
FIX: Fix report and ecg

### DIFF
--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -103,10 +103,11 @@ params.cov_rank = None  # preserve cov rank when using advanced estimators
 # Grad/Mag/EEG. Can also be a per-subject dict (or defaultdict), like:
 # Can also be a dict (including defaultdict). So let's set some defaults:
 params.proj_nums = dict(
-    subj_01=[[3, 3, 0], [3, 3, 2], [0, 0, 0]],
-    subj_02=[[3, 3, 0], [3, 3, 2], [0, 0, 0]],
+    subj_01=[[2, 2, 0], [1, 1, 3], [0, 0, 0]],
+    subj_02=[[2, 2, 0], [1, 1, 2], [0, 0, 0]],
     )
 params.proj_ave = True  # better projections by averaging ECG/EOG epochs
+params.eog_f_lims = [1, 10]  # band-pass limits for the EOG detection+artifacts
 
 # Set to True to use Autoreject module to set global epoch rejection thresholds
 params.autoreject_thresholds = False

--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -85,7 +85,7 @@ params.acq_dir = ['/sinuhe_data01/eric_non_space',
 
 # Set parameters for remotely connecting to SSS workstation ('sws')
 params.sws_ssh = 'kasga'
-params.sws_dir = '/data06/larsoner'
+params.sws_dir = '/data06/larsoner/sss_work'
 
 # Set the niprov handler to deal with events:
 params.on_process = handler
@@ -98,10 +98,14 @@ params.runs_empty = ['%s_erm']  # Define empty room runs
 params.compute_rank = True  # compute rank of the noise covariance matrix
 params.cov_rank = None  # preserve cov rank when using advanced estimators
 
-# Define number of SSP projectors. Columns correspond to Grad/Mag/EEG chans
-params.proj_nums = [[1, 1, 0],  # ECG
-                    [1, 1, 2],  # EOG
-                    [0, 0, 0]]  # Continuous (from ERM)
+# Define number of SSP projectors.
+# Three lists, one for ECG/EOG/continuous, each list with entries for
+# Grad/Mag/EEG. Can also be a per-subject dict (or defaultdict), like:
+# Can also be a dict (including defaultdict). So let's set some defaults:
+params.proj_nums = dict(
+    subj_01=[[3, 3, 0], [3, 3, 2], [0, 0, 0]],
+    subj_02=[[3, 3, 0], [3, 3, 2], [0, 0, 0]],
+    )
 params.proj_ave = True  # better projections by averaging ECG/EOG epochs
 
 # Set to True to use Autoreject module to set global epoch rejection thresholds

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1580,6 +1580,10 @@ def combine_medial_labels(labels, subject='fsaverage', surf='white',
 
 def _restrict_reject_flat(reject, flat, raw):
     """Restrict a reject and flat dict based on channel presence"""
+    reject = {} if reject is None else reject
+    flat = {} if flat is None else flat
+    assert isinstance(reject, dict())
+    assert isinstance(flat, dict())
     use_reject, use_flat = dict(), dict()
     for in_, out in zip([reject, flat], [use_reject, use_flat]):
         use_keys = [key for key in in_.keys() if key in raw]

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -440,6 +440,7 @@ class Params(Frozen):
         self.report_params = dict(
             good_hpi_count=True,
             head_movement=True,
+            raw_segments=True,
             psd=True,
             ssp_topomaps=True,
             source_alignment=True,

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2416,8 +2416,9 @@ def do_preprocessing_combined(p, subjects, run_indices):
 
             raw.filter(ecg_f_lims[0], ecg_f_lims[1], n_jobs=p.n_jobs_fir,
                        method='fir', filter_length=p.filter_length,
-                       **p.ecg_filt_kwargs, skip_by_annotation='edge',
-                       **old_kwargs)
+                       l_trans_bandwidth=0.5, h_trans_bandwidth=0.5,
+                       phase='zero-double', fir_window='hann',
+                       skip_by_annotation='edge', **old_kwargs)
             raw.add_proj(projs)
             raw.apply_proj()
             find_kwargs = dict()
@@ -2426,9 +2427,10 @@ def do_preprocessing_combined(p, subjects, run_indices):
             elif len(raw.annotations) > 0:
                 print('    WARNING: ECG event detection will not make use of '
                       'annotations, please update MNE-Python')
-            # We've already filtered the data above, so don't do it here
+            # We've already filtered the data channels above, but this
+            # filters the ECG channel
             ecg_events = find_ecg_events(
-                raw, 999, ecg_channel[subj], 0., None, None,
+                raw, 999, ecg_channel[subj], 0., 5, 35,
                 qrs_threshold='auto', return_ecg=False, **find_kwargs)[0]
             ecg_epochs = Epochs(
                 raw, ecg_events, 999, ecg_t_lims[0], ecg_t_lims[1],
@@ -2467,9 +2469,8 @@ def do_preprocessing_combined(p, subjects, run_indices):
                        skip_by_annotation='edge', **old_kwargs)
             raw.add_proj(projs)
             raw.apply_proj()
-            eog_events = find_eog_events(  # XXX remove copy
-                raw.copy(), ch_name=p.eog_channel, reject_by_annotation=True,
-                l_freq=None, h_freq=None)
+            eog_events = find_eog_events(
+                raw, ch_name=p.eog_channel, reject_by_annotation=True)
             eog_epochs = Epochs(
                 raw, eog_events, 998, eog_t_lims[0], eog_t_lims[1],
                 baseline=None, reject=p.ssp_eog_reject, preload=True)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2411,7 +2411,8 @@ def do_preprocessing_combined(p, subjects, run_indices):
             raw.apply_proj()
             pr = compute_proj_raw(raw, duration=1, n_grad=proj_nums[2][0],
                                   n_mag=proj_nums[2][1], n_eeg=proj_nums[2][2],
-                                  reject=None, flat=None, n_jobs=p.n_jobs_mkl)
+                                  reject=p.reject, flat=p.flat,
+                                  n_jobs=p.n_jobs_mkl)
             write_proj(cont_proj, pr)
             projs.extend(pr)
             del raw
@@ -2442,9 +2443,11 @@ def do_preprocessing_combined(p, subjects, run_indices):
             ecg_events = find_ecg_events(
                 raw, 999, ecg_channel, 0., ecg_f_lims[0], ecg_f_lims[1],
                 qrs_threshold='auto', return_ecg=False, **find_kwargs)[0]
+            use_reject, use_flat = _restrict_reject_flat(
+                p.ssp_ecg_reject, p.flat, raw)
             ecg_epochs = Epochs(
                 raw, ecg_events, 999, ecg_t_lims[0], ecg_t_lims[1],
-                baseline=None, reject=p.ssp_ecg_reject, preload=True)
+                baseline=None, reject=use_reject, flat=use_flat, preload=True)
             print('  obtained %d epochs from %d events.' % (len(ecg_epochs),
                                                             len(ecg_events)))
             if len(ecg_epochs) >= 20:
@@ -2481,9 +2484,11 @@ def do_preprocessing_combined(p, subjects, run_indices):
             raw.apply_proj()
             eog_events = find_eog_events(
                 raw, ch_name=p.eog_channel, reject_by_annotation=True)
+            use_reject, use_flat = _restrict_reject_flat(
+                p.ssp_eog_reject, p.flat, raw)
             eog_epochs = Epochs(
                 raw, eog_events, 998, eog_t_lims[0], eog_t_lims[1],
-                baseline=None, reject=p.ssp_eog_reject, preload=True)
+                baseline=None, reject=use_reject, flat=use_flat, preload=True)
             print('  obtained %d epochs from %d events' % (len(eog_epochs),
                                                            len(eog_events)))
             del eog_events

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -269,9 +269,13 @@ class Params(Frozen):
         Default is False. Set to True to compute rank of the noise covariance
         matrix during inverse kernel computation.
     eog_t_lims : tuple
-        The time limits for EOG calculation.
+        The time limits for EOG calculation. Default (-0.25, 0.25).
     ecg_t_lims : tuple
-        The time limits for ECG calculation.
+        The time limits for ECG calculation. Default(-0.08, 0.08).
+    eog_f_lims : tuple
+        Band-pass limits for EOG detection and calculation. Default (0, 2).
+    ecg_f_lims : tuple
+        Band-pass limits for ECG detection and calculation. Default (5, 35).
     proj_nums : list | dict
         List of projector counts to use for ECG/EOG/ERM; each list contains
         three values for grad/mag/eeg channels.

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -1582,8 +1582,8 @@ def _restrict_reject_flat(reject, flat, raw):
     """Restrict a reject and flat dict based on channel presence"""
     reject = {} if reject is None else reject
     flat = {} if flat is None else flat
-    assert isinstance(reject, dict())
-    assert isinstance(flat, dict())
+    assert isinstance(reject, dict)
+    assert isinstance(flat, dict)
     use_reject, use_flat = dict(), dict()
     for in_, out in zip([reject, flat], [use_reject, use_flat]):
         use_keys = [key for key in in_.keys() if key in raw]

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2085,6 +2085,10 @@ def gen_covariances(p, subjects, run_indices):
             raw.pick_types(meg=True, eog=True, exclude='bads')
             use_reject, use_flat = _restrict_reject_flat(
                 reject, p.flat, raw)
+            if 'eeg' in use_reject:
+                del use_reject['eeg']
+            if 'eeg' in use_flat:
+                del use_flat['eeg']
             cov = compute_raw_covariance(raw, reject=use_reject, flat=use_flat,
                                          method=p.cov_method, **kwargs_erm)
             write_cov(empty_cov_name, cov)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -459,6 +459,8 @@ class Params(Frozen):
         self.force_erm_cov_rank_full = True  # force empty-room inv rank
         self.eog_t_lims = (-0.25, 0.25)
         self.ecg_t_lims = (-0.08, 0.08)
+        self.eog_f_lims = (0, 2)
+        self.ecg_f_lims = (5, 35)
         self.freeze()
 
     @property
@@ -2333,8 +2335,8 @@ def do_preprocessing_combined(p, subjects, run_indices):
 
         eog_t_lims = p.eog_t_lims
         ecg_t_lims = p.ecg_t_lims
-        eog_f_lims = [0, 2]
-        ecg_f_lims = [5, 35]
+        eog_f_lims = p.eog_f_lims
+        ecg_f_lims = p.ecg_f_lims
 
         ecg_eve = op.join(pca_dir, 'preproc_ecg-eve.fif')
         ecg_epo = op.join(pca_dir, 'preproc_ecg-epo.fif')
@@ -2429,7 +2431,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
             # We've already filtered the data channels above, but this
             # filters the ECG channel
             ecg_events = find_ecg_events(
-                raw, 999, ecg_channel, 0., 5, 35,
+                raw, 999, ecg_channel, 0., ecg_f_lims[0], ecg_f_lims[1],
                 qrs_threshold='auto', return_ecg=False, **find_kwargs)[0]
             ecg_epochs = Epochs(
                 raw, ecg_events, 999, ecg_t_lims[0], ecg_t_lims[1],

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -178,9 +178,10 @@ class Params(Frozen):
     auto_bad : float | None
         If not None, bad channels will be automatically excluded if
         they disqualify a proportion of events exceeding ``autobad``.
-    ecg_channel : str | list of str | None
+    ecg_channel : str | dict | None
         The channel to use to detect ECG events. None will use ECG063.
         In lieu of an ECG recording, MEG1531 may work.
+        Can be a dict that maps subject names to channels.
     eog_channel : str
         The channel to use to detect EOG events. None will use EOG*.
         In lieu of an EOG recording, MEG1411 may work.
@@ -271,6 +272,10 @@ class Params(Frozen):
         The time limits for EOG calculation.
     ecg_t_lims : tuple
         The time limits for ECG calculation.
+    proj_nums : list | dict
+        List of projector counts to use for ECG/EOG/ERM; each list contains
+        three values for grad/mag/eeg channels.
+        Can be a dict that maps subject names to projector counts to use.
 
     Returns
     -------

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -189,7 +189,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                         figwidth=12)
                 fig.subplots_adjust(0.0, 0.0, 1, 1, 0, 0)
                 report.add_figs_to_section(fig, 'Processed', section,
-                                           image_format='png')  # svd too slow
+                                           image_format='png')  # svg too slow
 
             #
             # PSD

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -27,7 +27,8 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
     import matplotlib.pyplot as plt
     from ._mnefun import (_load_trans_to, plot_good_coils, _head_pos_annot,
                           _get_bem_src_trans, safe_inserter, _prebad,
-                          _load_meg_bads, mlab_offscreen, _fix_raw_eog_cals)
+                          _load_meg_bads, mlab_offscreen, _fix_raw_eog_cals,
+                          _handle_dict)
     if run_indices is None:
         run_indices = [None] * len(subjects)
     style = {'axes.spines.right': 'off', 'axes.spines.top': 'off',
@@ -236,8 +237,9 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
             #
             section = 'SSP topomaps'
 
+            proj_nums = _handle_dict(p.proj_nums, subj)
             if p.report_params.get('ssp_topomaps', True) and has_pca and \
-                    np.sum(_get_proj_nums(p, subj)) > 0:
+                    np.sum(proj_nums) > 0:
                 assert sss_info is not None
                 t0 = time.time()
                 print(('    %s ... ' % section).ljust(ljust), end='')
@@ -250,19 +252,19 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                               p.proj_extra))
                     figs.append(plot_projs_topomap(projs, info=sss_info,
                                                    show=False))
-                if any(p.proj_nums[0]):  # ECG
+                if any(proj_nums[0]):  # ECG
                     if 'preproc_ecg-proj.fif' in proj_files:
                         comments.append('ECG')
                         figs.append(_proj_fig(op.join(
                             p.work_dir, subj, p.pca_dir,
                             'preproc_ecg-proj.fif'), sss_info))
-                if any(p.proj_nums[1]):  # EOG
+                if any(proj_nums[1]):  # EOG
                     if 'preproc_blink-proj.fif' in proj_files:
                         comments.append('Blink')
                         figs.append(_proj_fig(op.join(
                             p.work_dir, subj, p.pca_dir,
                             'preproc_blink-proj.fif'), sss_info))
-                if any(p.proj_nums[2]):  # ERM
+                if any(proj_nums[2]):  # ERM
                     if 'preproc_blink-cont.fif' in proj_files:
                         comments.append('Continuous')
                         figs.append(_proj_fig(op.join(

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -69,6 +69,9 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
         # whitening and source localization
         inv_dir = op.join(p.work_dir, subj, p.inverse_dir)
 
+        has_fwd = op.isfile(op.join(p.work_dir, subj, p.forward_dir,
+                                    subj + p.inv_tag + '-fwd.fif'))
+
         with plt.style.context(style):
             ljust = 25
             #
@@ -242,7 +245,8 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
             # Source alignment
             #
             section = 'Source alignment'
-            if p.report_params.get('source_alignment', True) and has_sss:
+            if p.report_params.get('source_alignment', True) and has_sss \
+                    and has_fwd:
                 assert sss_info is not None
                 t0 = time.time()
                 print(('    %s ... ' % section).ljust(ljust), end='')
@@ -316,9 +320,11 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                            % (analysis, p.lp_cut, p.inv_tag,
                                               p.eq_tag, subj))
                     if not op.isfile(fname_inv):
-                        print('Missing inv: %s' % fname_inv)
+                        print('    Missing inv: %s'
+                              % op.basename(fname_inv), end='')
                     elif not op.isfile(fname_evoked):
-                        print('Missing evoked: %s' % fname_evoked)
+                        print('    Missing evoked: %s'
+                              % op.basename(fname_evoked), end='')
                     else:
                         inv = mne.minimum_norm.read_inverse_operator(fname_inv)
                         this_evoked = mne.read_evokeds(fname_evoked, name)
@@ -338,7 +344,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
             # BEM
             #
             section = 'BEM'
-            if p.report_params.get('bem', True):
+            if p.report_params.get('bem', True) and has_fwd:
                 caption = '%s<br>%s' % (section, struc)
                 bem, src, trans, _ = _get_bem_src_trans(
                     p, raw.info, subj, struc)
@@ -386,9 +392,11 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                            % (analysis, p.lp_cut, p.inv_tag,
                                               p.eq_tag, subj))
                     if not op.isfile(cov_name):
-                        print('Missing cov: %s' % cov_name)
+                        print('    Missing cov: %s'
+                              % op.basename(cov_name), end='')
                     elif not op.isfile(fname_evoked):
-                        print('Missing evoked: %s' % fname_evoked)
+                        print('    Missing evoked: %s'
+                              % op.basename(fname_evoked), end='')
                     else:
                         noise_cov = mne.read_cov(cov_name)
                         evo = mne.read_evokeds(fname_evoked, name)
@@ -420,7 +428,8 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                            % (analysis, p.lp_cut, p.inv_tag,
                                               p.eq_tag, subj))
                     if not op.isfile(fname_evoked):
-                        print('Missing evoked: %s' % fname_evoked)
+                        print('    Missing evoked: %s'
+                              % op.basename(fname_evoked), end='')
                     else:
                         this_evoked = mne.read_evokeds(fname_evoked, name)
                         figs = this_evoked.plot_joint(
@@ -458,9 +467,11 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                            % (analysis, p.lp_cut, p.inv_tag,
                                               p.eq_tag, subj))
                     if not op.isfile(fname_inv):
-                        print('Missing inv: %s' % fname_inv)
+                        print('    Missing inv: %s'
+                              % op.basename(fname_inv), end='')
                     elif not op.isfile(fname_evoked):
-                        print('Missing evoked: %s' % fname_evoked)
+                        print('    Missing evoked: %s'
+                              % op.basename(fname_evoked), end='')
                     else:
                         inv = mne.minimum_norm.read_inverse_operator(fname_inv)
                         this_evoked = mne.read_evokeds(fname_evoked, name)


### PR DESCRIPTION
Functionality to `mnefun` (@larsoner):

- [x] allow `ecg_channel` to be set on a per-subject basis
- [x] save `-reject.h5` params when using autoreject, and use these when computing the covariance
- [x] adjustable ExG window size (tmin/tmax)
- [x] make sure that ExG calculations respect the `BAD_` annotations
- [x] implement variable number of projectors per subject
- [x] check that projectors before and after changes are similar
- [x] add support for custom annotations (preexisting)
- [ ] ~~warning for large deflections of ExG~~

To `mnefun` report:
- [x] fix bug where alignment isn't properly disabled when isn't available
- [x] plot the ExG evoked in report
- [x] plot the ExG projectors applied to the evoked (1 waveform per projector)
- [x] plot 10 segments of `raw` evenly spaced before SSP and after SSP (`raw.plot(..., group_by='selection')`)
- [x] plot cHPI SNR
- [x] test that report actually looks okay

For now, not adding the warning for large ExG deflections since hopefully this will be automatically handled by discarding annotated segments now.