### PR TITLE
ENH: Use cross validated rejection criteria for bad channel selection

### DIFF
--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -115,10 +115,14 @@ params.proj_meg = 'combined'  # jointly estimate MEG projectors
 params.proj_ave = True  # better projections by averaging ECG/EOG epochs
 params.eog_f_lims = [1, 10]  # band-pass limits for the EOG detection+artifacts
 
-# Set to True to use Autoreject module to set global epoch rejection thresholds
+# Set to True to use Autoreject module to compute noisy sensor thresholds for
+# epoching
 params.autoreject_thresholds = False
 # Set to ('meg', 'eeg', eog') to reject trials based on EOG
 params.autoreject_types = ('mag', 'grad', 'eeg')
+# To define noisy sensor thresholds set to 'auto' to compute values with
+# Autoreject module # or e.g., # dict(grad=1500e-13, mag=5000e-15, eeg=150e-6).
+params.auto_bad_reject = None
 params.cov_method = 'shrunk'  # Cleaner noise covariance regularization
 # python | maxfilter for choosing SSS applied using either Maxfilter or MNE
 params.sss_type = 'python'

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2422,7 +2422,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
             assert p.auto_bad_flat is None or isinstance(p.auto_bad_flat, dict)
             assert p.auto_bad_reject is None or isinstance(p.auto_bad_reject,
                                                            dict) or \
-                   p.auto_bad_reject is 'auto'
+                   p.auto_bad_reject == 'auto'
             if p.auto_bad_reject is 'auto':
                 print('    Auto bad channel selection active. '
                       'Will try using Autoreject module to '

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2436,18 +2436,16 @@ def do_preprocessing_combined(p, subjects, run_indices):
                                       '     channel selection either define '
                                       '     rejection criteria or install '
                                       '     Autoreject module.\n')
-                else:
-                    print('    Computing thresholds.\n', end='')
-                    temp_epochs = Epochs(
-                            raw, events, event_id=None, tmin=rtmin, tmax=rtmax,
-                            baseline=_get_baseline(p), proj=True, reject=None,
-                            flat=None,
-                            preload=True, decim=1)
-                    kwargs = dict()
-                    if 'verbose' in get_args(get_rejection_threshold):
-                        kwargs['verbose'] = False
-                    reject = get_rejection_threshold(temp_epochs, **kwargs)
-                    reject = {kk: vv for kk, vv in reject.items()}
+                print('    Computing thresholds.\n', end='')
+                temp_epochs = Epochs(
+                    raw, events, event_id=None, tmin=rtmin, tmax=rtmax,
+                    baseline=_get_baseline(p), proj=True, reject=None,
+                    flat=None, preload=True, decim=1)
+                kwargs = dict()
+                if 'verbose' in get_args(get_rejection_threshold):
+                    kwargs['verbose'] = False
+                reject = get_rejection_threshold(temp_epochs, **kwargs)
+                reject = {kk: vv for kk, vv in reject.items()}
             elif p.auto_bad_reject is None and p.auto_bad_flat is None:
                 raise RuntimeError('Auto bad channel detection active. Noisy '
                                    'and flat channel detection '

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -185,7 +185,7 @@ class Params(Frozen):
         they disqualify a proportion of events exceeding ``autobad``.
     auto_bad_reject : str | dict
         Default is None. Must be defined if using Autoreject module to
-        compute noisy sensor rejection ctriteria. Set to 'auto' to compute
+        compute noisy sensor rejection criteria. Set to 'auto' to compute
         criteria automatically, or dictionary of channel keys and amplitude
         values e.g., dict(grad=1500e-13, mag=5000e-15, eeg=150e-6) to define
         rejection threshold(s). See

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -183,7 +183,7 @@ class Params(Frozen):
     auto_bad : float | None
         If not None, bad channels will be automatically excluded if
         they disqualify a proportion of events exceeding ``autobad``.
-    auto_bad_reject : str | dict
+    auto_bad_reject : str | dict | None
         Default is None. Must be defined if using Autoreject module to
         compute noisy sensor rejection criteria. Set to 'auto' to compute
         criteria automatically, or dictionary of channel keys and amplitude

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2426,7 +2426,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
             if p.auto_bad_reject is 'auto':
                 print('    Auto bad channel selection active. '
                       'Will try using Autoreject module to '
-                      'compute rejection criterion.\n' , end='')
+                      'compute rejection criterion.')
                 try:
                     from autoreject import get_rejection_threshold
                 except ImportError:

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2429,7 +2429,15 @@ def do_preprocessing_combined(p, subjects, run_indices):
                       'compute rejection criterion.\n' , end='')
                 try:
                     from autoreject import get_rejection_threshold
-                    print('    Computing autoreject thresholds.\n', end='')
+                except ImportError:
+                    raise ImportError('     Autoreject module not installed.\n'
+                                      '     Noisy channel detection parameter '
+                                      '     not defined. To use autobad '
+                                      '     channel selection either define '
+                                      '     rejection criteria or install '
+                                      '     Autoreject module.\n')
+                else:
+                    print('    Computing thresholds.\n', end='')
                     temp_epochs = Epochs(
                             raw, events, event_id=None, tmin=rtmin, tmax=rtmax,
                             baseline=_get_baseline(p), proj=True, reject=None,
@@ -2440,12 +2448,6 @@ def do_preprocessing_combined(p, subjects, run_indices):
                         kwargs['verbose'] = False
                     reject = get_rejection_threshold(temp_epochs, **kwargs)
                     reject = {kk: vv for kk, vv in reject.items()}
-                except ImportError:
-                    print('     Autoreject module not installed.\n'
-                          '     Noisy channel detection parameter not defined. '
-                          '     To use autobad channel selection either '
-                          '     define rejection criterion or install '
-                          '     Autoreject module.')
             elif p.auto_bad_reject is None and p.auto_bad_flat is None:
                 raise RuntimeError('Auto bad channel detection active. Noisy '
                                    'and flat channel detection '

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2423,7 +2423,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
             assert p.auto_bad_reject is None or isinstance(p.auto_bad_reject,
                                                            dict) or \
                    p.auto_bad_reject == 'auto'
-            if p.auto_bad_reject is 'auto':
+            if p.auto_bad_reject == 'auto':
                 print('    Auto bad channel selection active. '
                       'Will try using Autoreject module to '
                       'compute rejection criterion.')


### PR DESCRIPTION
Enable user to use CV rejection criteria in autoreject module during automatic bad channel selection routine:
- Use pre-computed rejection criteria if the container `h5` file corresponding to epochs file exists OR
- Use Autoreject to compute criteria on the fly
-  If neither option is available fall back to the user-defined rejection criteria. 

@larsoner LMKWYT