### PR TITLE
BUG: Dont use autobad, pass bads explicitly

### DIFF
--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -189,10 +189,10 @@ params.report_params.update(  # add a couple of nice diagnostic plots
 )
 
 # Set what processing steps will execute
-default = True
+default = False
 mnefun.do_processing(
     params,
-    fetch_raw=False,     # Fetch raw recording files from acquisition machine
+    fetch_raw=default,     # Fetch raw recording files from acquisition machine
     do_score=default,      # Do scoring to slice data into trials
 
     # Before running SSS, make SUBJ/raw_fif/SUBJ_prebad.txt file with

--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -88,9 +88,22 @@ params.acq_dir = ['/sinuhe_data01/eric_non_space',
                   '/sinuhe/data02/eric_non_space',
                   '/sinuhe/data03/eric_non_space']
 
-# Set parameters for remotely connecting to SSS workstation ('sws')
-params.sws_ssh = 'kasga'
-params.sws_dir = '/data06/larsoner/sss_work'
+# Parameters for remotely connecting to SSS workstation ('sws') can be set
+# by adding a file ~/.mnefun/mnefun.json with contents like:
+#
+#     $ mkdir ~/.mnefun
+#     $ echo '{"sws_ssh":"kasga","sws_dir":"/data06/larsoner/sss_work","sws_port":22}' > ~/.mnefun/mnefun.json
+#
+# This should be preferred to the old way, which was to set in each script
+# when running on your machine:
+#
+#     params.sws_ssh = 'kasga'
+#     params.sws_dir = '/data06/larsoner/sss_work'
+#
+# Using per-machine config files rather than per-script variables should
+# help increase portability of scripts without hurting reproducibility
+# (assuming we all use the same version of MaxFilter, which should be a
+# safe assumption).
 
 # Set the niprov handler to deal with events:
 params.on_process = handler
@@ -166,19 +179,20 @@ params.report_params.update(  # add a couple of nice diagnostic plots
     snr=dict(analysis='All', name='All',
              inv='%s-55-sss-meg-eeg-free-inv.fif'),
     bem=True,  # BEM layers
+    covariance=True,  # covariance image and SVD plots
     whitening=dict(analysis='All', name='All',
                    cov='%s-55-sss-cov.fif'),
     sensor=dict(analysis='All', name='All', times=[0.1, 0.2]),
     source=dict(analysis='All', name='All',
                 inv='%s-55-sss-meg-eeg-free-inv.fif', times=[0.09, 0.4],
                 views='lat', size=(800, 400)),
-) 
+)
 
 # Set what processing steps will execute
-default = False
+default = True
 mnefun.do_processing(
     params,
-    fetch_raw=default,     # Fetch raw recording files from acquisition machine
+    fetch_raw=False,     # Fetch raw recording files from acquisition machine
     do_score=default,      # Do scoring to slice data into trials
 
     # Before running SSS, make SUBJ/raw_fif/SUBJ_prebad.txt file with

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -3164,16 +3164,13 @@ def plot_colorbar(lims, ticks=None, ticklabels=None, figsize=(1, 2),
             use_lims = dict(kind='value', pos_lims=lims)
         else:
             use_lims = dict(kind='value', lims=lims)
-        cmap, scale_pts, diverging, _ = mne.viz._3d._limits_to_control_points(
-            use_lims, 0, colormap, transparent,
-            linearize=True)
+        cmap, scale_pts, diverging, _, none_ticks = \
+            mne.viz._3d._limits_to_control_points(
+                use_lims, 0, colormap, transparent,
+                linearize=True)
         vmin, vmax = scale_pts[0], scale_pts[-1]
         if ticks is None:
-            if diverging:
-                ticks = [-lims[2], -lims[1], -lims[0], 0.,
-                         lims[0], lims[1], lims[2]]
-            else:
-                ticks = [lims[0], np.mean(lims), lims[1]]
+            ticks = none_ticks
         del colormap, lims, use_lims
         adjust = (ax is None)
         if ax is None:


### PR DESCRIPTION
This code makes a few important changes:

1. When calculating the `head_pos` using MaxFilter in `master`, the implicit bad option was `-autobad on` (MF default). Now we set `-autobad off` and pass our explicit bad list. This will be combined with MF autobad channels list if and only if `params.mf_autobad = True`.
2. When calculating our estimates of the number of good HPI coils in Python, the same list of bad channels is now used that was used during head position estimation (before we didn't set any bads!). This might explain discrepancies where MF has been able to calculate the head position just fine, but our Python-based number-of-good-cHPI-coil counts were less than 3.
3. Makes some minor fixes about when to replace MF position values (though after point (1) above this was no longer necessary).
4. Adds `covariance` option to reports, which is useful for debugging rank problems.
5. Adds the option for a static config file to avoid the need of setting `sws_ssh`, `sws_dir`, and `sws_port` all the time (and switching it when scripts are transported across machines). This should increase script portability for testing.

And minor stuff:

1. Makes it so that figures do not pop up during report generation.
2. Cleans up report section names.
3. Adds `params.eog_thresh` to help control EOG peak detection, which I needed for some particularly noisy subjects where it found, say, 2-10 peaks in an entire 40 minute session because they had a few major-league blinks that made the algorithm miss the mundane ones.

I'd recommend re-running head pos estimation and `-annot.fif` generation subjects for which the HPI coil count was bad a lot previously, hopefully the numbers go up! If they don't, try it with `params.mf_autobad = True` (if you don't have it set already), as this should get you back to at least as good as it is currently in `master`.

@ktavabi @nordme @mdclarke @drammock sound reasonable to you? If so please look at the code and let me know if you're happy.

@nordme this fixes the PreK error for me, feel free to try it (after deleting `.pos` and `.annot` files) and let me know if it works for you, too.