### PR TITLE
FIX: Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 auto_examples
 generated
+.vscode
 
 # C extensions
 *.so

--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -120,7 +120,8 @@ params.force_erm_cov_rank_full = False  # compute and use the empty-room rank
 # (must be same length as ``params.subjects``) or a dict (keys are subject
 # strings, values are the run indices) including a defaultdict. None is an
 # alias for "all runs".
-params.subject_run_indices = [None, [0]]  # same in this case
+# We have 2 subjs and 1 run per subj, so `None` or `[0]` both select all runs
+params.subject_run_indices = [None, [0]]
 
 # Define number of SSP projectors.
 # Three lists, one for ECG/EOG/continuous, each list with entries for

--- a/examples/funloc/analysis_fun.py
+++ b/examples/funloc/analysis_fun.py
@@ -116,6 +116,11 @@ params.runs_empty = ['%s_erm']  # Define empty room runs
 params.compute_rank = True  # compute rank of the noise covariance matrix
 params.cov_rank = None  # preserve cov rank when using advanced estimators
 params.force_erm_cov_rank_full = False  # compute and use the empty-room rank
+# You can choose different run indices for subjects. This can be a list
+# (must be same length as ``params.subjects``) or a dict (keys are subject
+# strings, values are the run indices) including a defaultdict. None is an
+# alias for "all runs".
+params.subject_run_indices = [None, [0]]  # same in this case
 
 # Define number of SSP projectors.
 # Three lists, one for ECG/EOG/continuous, each list with entries for

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -688,10 +688,14 @@ def do_processing(p, fetch_raw=False, do_score=False, push_raw=False,
 
     run_indices = p.subject_run_indices
     if run_indices is None:
-        run_indices = [None] * len(p.subjects)
-    assert len(run_indices) == len(p.subjects)
-    run_indices = [np.array(run_indices[si]) if run_indices[si] is not None
-                   else np.arange(len(p.run_namus)for si in sinds]
+        run_indices = [None] * len(subjects)
+    elif isinstance(run_indices, dict):
+        run_indices = [run_indices[subject] for subject in subjects]
+    else:
+        run_indices = [run_indices[si] for si in sinds]
+        assert len(run_indices) == len(p.subjects)
+    run_indices = [np.array(run_idx) if run_idx is not None
+                   else np.arange(len(p.run_names)) for run_idx in run_indices]
     assert all(run_idx.ndim == 1 for run_idx in run_indices)
     assert all(np.in1d(r, np.arange(len(p.run_names))).all()
                for r in run_indices)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -690,8 +690,10 @@ def do_processing(p, fetch_raw=False, do_score=False, push_raw=False,
     if run_indices is None:
         run_indices = [None] * len(p.subjects)
     assert len(run_indices) == len(p.subjects)
-    run_indices = [r for ri, r in enumerate(run_indices) if ri in sinds]
-    assert all(r is None or np.in1d(r, np.arange(len(p.run_names))).all()
+    run_indices = [np.array(run_indices[si]) if run_indices[si] is not None
+                   else np.arange(len(p.run_namus)for si in sinds]
+    assert all(run_idx.ndim == 1 for run_idx in run_indices)
+    assert all(np.in1d(r, np.arange(len(p.run_names))).all()
                for r in run_indices)
 
     # Actually do the work

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -2300,7 +2300,8 @@ def gen_covariances(p, subjects, run_indices, decim):
             epochs = Epochs(raw, events, event_id=None, tmin=p.bmin,
                             tmax=p.bmax, baseline=(None, None), proj=False,
                             reject=use_reject, flat=use_flat, preload=True,
-                            decim=decim[si], verbose='error',    # ignore decim
+                            decim=decim[si],
+                            verbose='error',  # ignore decim-related warnings
                             on_missing=p.on_missing,
                             reject_by_annotation=p.reject_epochs_by_annot)
             epochs.pick_types(meg=True, eeg=True, exclude=[])

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -493,6 +493,7 @@ class Params(Frozen):
         self.compute_rank = False
         self.cov_rank = 'full'
         self.force_erm_cov_rank_full = True  # force empty-room inv rank
+        self.cov_rank_tol = 1e-6
         self.eog_t_lims = (-0.25, 0.25)
         self.ecg_t_lims = (-0.08, 0.08)
         self.eog_f_lims = (0, 2)
@@ -1967,12 +1968,12 @@ def _compute_rank(p, subj, run_indices):
             key = 'meg'
         else:
             key = 'grad' if 'grad' in epochs else 'mag'
-        rank[key] = estimate_rank(eps, tol=1e-6)
+        rank[key] = estimate_rank(eps, tol=p.cov_rank_tol)
     if eeg:
         eps = epochs.copy().pick_types(meg=False, eeg=eeg).apply_proj()
         eps = eps.get_data().transpose([1, 0, 2])
         eps = eps.reshape(len(eps), -1)
-        rank['eeg'] = estimate_rank(eps, tol=1e-6)
+        rank['eeg'] = estimate_rank(eps, tol=p.cov_rank_tol)
     for k, v in rank.items():
         print(' : %s rank %2d' % (k.upper(), v), end='')
     return rank

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -114,7 +114,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                         p, subj, fname, prefix='      ')
                     if fit_data is None:
                         print('%s skipped, HPI count data not found (possibly '
-                              'no params.*_limit values set?' % (section,))
+                              'no params.*_limit values set?)' % (section,))
                         break
                     fig = plot_good_coils(fit_data, show=False)
                     fig.set_size_inches(10, 2)

--- a/mnefun/misc.py
+++ b/mnefun/misc.py
@@ -10,33 +10,37 @@ def make_montage(info, kind, check=False):
     from . import _reorder
     assert kind in ('mgh60', 'mgh70', 'uw_70', 'uw_60')
     picks = mne.pick_types(info, meg=False, eeg=True, exclude=())
-    if kind in ('mgh60', 'mgh70'):
-        ch_names = mne.utils._clean_names(
-            [info['ch_names'][pick] for pick in picks], remove_whitespace=True)
-        if kind == 'mgh60':
-            assert len(ch_names) in (59, 60)
-        else:
-            assert len(ch_names) in (70,)
-        montage = mne.channels.read_montage(kind, ch_names=ch_names)
-    else:
-        ch_names = getattr(_reorder, 'ch_names_' + kind)
-        ch_names = ch_names
-        montage = mne.channels.read_montage('standard_1020', ch_names=ch_names)
-        assert len(montage.ch_names) == len(ch_names)
-        montage.ch_names = ['EEG%03d' % ii for ii in range(1, 61)]
     sphere = mne.make_sphere_model('auto', 'auto', info)
-    montage.pos /= np.linalg.norm(montage.pos, axis=-1, keepdims=True)
-    montage.pos *= sphere.radius
-    montage.pos += sphere['r0']
     info = mne.pick_info(info, picks)
+    to_names = info['ch_names']
+    if kind in ('mgh60', 'mgh70'):
+        if kind == 'mgh60':
+            assert len(to_names) in (59, 60)
+        else:
+            assert len(to_names) in (70,)
+        montage = mne.channels.make_standard_montage(
+            kind, head_size=sphere.radius)
+        from_names = mne.utils._clean_names(to_names, remove_whitespace=True)
+    else:
+        assert len(to_names) == 60
+        from_names = getattr(_reorder, 'ch_names_' + kind)
+        montage = mne.channels.make_standard_montage(
+            'standard_1020', head_size=sphere.radius)
+    assert len(from_names) == len(to_names)
+    montage_pos = montage._get_ch_pos()
+    montage = mne.channels.make_dig_montage(
+        {to: montage_pos[fro] for fro, to in zip(from_names, to_names)},
+        coord_frame='head')
     eeg_pos = np.array([ch['loc'][:3] for ch in info['chs']])
-    assert len(eeg_pos) == len(montage.pos), (len(eeg_pos), len(montage.pos))
+    montage_pos = montage._get_ch_pos()
+    montage_pos = np.array([montage_pos[name] for name in to_names])
+    assert len(eeg_pos) == len(montage_pos)
     if check:
         from mayavi import mlab
         mlab.figure(size=(800, 800))
         mlab.points3d(*sphere['r0'], scale_factor=2 * sphere.radius,
                       color=(0., 0., 1.), opacity=0.1, mode='sphere')
-        mlab.points3d(*montage.pos.T, scale_factor=0.01,
+        mlab.points3d(*montage_pos.T, scale_factor=0.01,
                       color=(1, 0, 0), mode='sphere', opacity=0.5)
         mlab.points3d(*eeg_pos.T, scale_factor=0.005, color=(1, 1, 1),
                       mode='sphere', opacity=1)


### PR DESCRIPTION
1. Unifies how `epochs` are created in `save_epochs` and in `gen_covariances`. Critically the `reject_by_annotation` param differed, which seemed to be breaking the rank estimation.
2. Cleans up the decisions about when the annotation code prints.
3. Fixes a documentation bug about `int_order` vs `ext_order` for infant data.
4. Allows setting `params.cov_rank_tol` to something higher than the default (1e-6).

@nordme @drammock can you see if (1) this fixes your error?

Even after (1), though, I found that some conditions had a bit of a whitening problem in the reports, which could be fixed by (4), namely setting `params.cov_rank_tol = 1e-2`. This seems a bit high, though, so alternatively using `params.cov_method='shrunk'` (instead of `'empirical'`) might be a better choice, as it also fixes the problem and is probably more robust than trying to tweak the cutoff value.

Also you probably want to add `params.proj_meg = 'combined'` to your processing scripts because it works a bit better.

Closes #263.