### PR TITLE
MRG, ENH:  Use peak times for sensor and source plots in .html reports

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,9 @@ Changelog
 
 2020
 ^^^^
+- 2020/03/22
+    Added peak-detection capability to reports for the sensor and source
+    sections, using ``times='peaks'``. Peaks are based on evoked gfp.
 - 2020/03/06
     Added Python-based Maxwell-filter automatic bad channel detection
     using ``mf_autobad_type='python'``.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,9 +11,9 @@ Changelog
 
 2020
 ^^^^
-- 2020/03/22
+- 2020/04/01
     Added peak-detection capability to reports for the sensor and source
-    sections, using ``times='peaks'``. Peaks are based on evoked gfp.
+    sections, using ``times='peaks'``. Peaks are based on whitened gfps.
 - 2020/03/06
     Added Python-based Maxwell-filter automatic bad channel detection
     using ``mf_autobad_type='python'``.

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -96,6 +96,6 @@ inverse:
 report:
   snr: {analysis: All, name: All, inv: '%s-50-sss-meg-eeg-free-inv.fif'}
   whitening: {analysis: All, name: All}
-  sensor: {analysis: All, name: All, times: [0.1, 0.2]}
+  sensor: {analysis: All, name: All, times: 'peaks'}
   source: {analysis: All, name: All, inv: '%s-50-sss-meg-eeg-free-inv.fif',
            times: 'peaks', views: lat, size: [800, 400]}

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -98,4 +98,4 @@ report:
   whitening: {analysis: All, name: All}
   sensor: {analysis: All, name: All, times: [0.1, 0.2]}
   source: {analysis: All, name: All, inv: '%s-50-sss-meg-eeg-free-inv.fif',
-           times: [0.09, 0.4], views: lat, size: [800, 400]}
+           times: 'peaks', views: lat, size: [800, 400]}

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -270,7 +270,7 @@ def _peak_times(evoked, max_peaks=5):
         gfp = gfp / gfp.max()
     else:
         gfp = np.array(gfp_list).mean(axis=0)
-    npeaks = max(min(len(gfp) // 3, max_peaks), 1) # 1 <= npeaks <= max_peaks
+    npeaks = max(min(len(gfp) // 3, max_peaks), 1)  # npeaks >=1, <= max_peaks
     peaks = find_peaks(gfp)[0]
     prms = peak_prominences(gfp, peaks)[0]
     times = peaks[prms.argsort()[::-1]][:npeaks]

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -260,28 +260,27 @@ def _peak_times(evoked, max_peaks=5):
     if 'meg' in evoked:
         evk = evoked.copy().pick_types(meg=True)
         gfp = evk.data.std(axis=0)
-        gfp_list.append(gfp/gfp.max())
+        gfp_list.append(gfp / gfp.max())
     if 'eeg' in evoked:
         evk = evoked.copy().pick_types(meg=False, eeg=True)
         gfp = evk.data.std(axis=0)
-        gfp_list.append(gfp/gfp.max())
+        gfp_list.append(gfp / gfp.max())
     if not gfp_list:    # for non-meg/eeg data types
         gfp = evoked.data.std(axis=0)
-        gfp = gfp/gfp.max()
+        gfp = gfp / gfp.max()
     else:
         gfp = np.array(gfp_list).mean(axis=0)
-                        # no less than 1, no more than max_peaks
-    npeaks = max(min(len(gfp)//3, max_peaks), 1)
+    npeaks = max(min(len(gfp) // 3, max_peaks), 1) # 1 <= npeaks <= max_peaks
     peaks = find_peaks(gfp)[0]
     prms = peak_prominences(gfp, peaks)[0]
     times = peaks[prms.argsort()[::-1]][:npeaks]
     times.sort()
-    
     if not len(times):  # guarantee at least 1
         times = gfp.argmax()
     times = evoked.times[times]  # convert units to seconds
-    
-    print('Local peak times calculated at', times, 'sec.')
+    # print('Local peak times calculated at', times, 'sec.')
+    print('Auto peak time%s: %s ' % (_pl(times), ','.join('%0.3f'
+          % t for t in times),), end='')
     return times
 
 
@@ -504,7 +503,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                 print('%5.1f sec' % ((time.time() - t0),))
             else:
                 print('    %s skipped' % section)
-            
+
             #
             # Drop log
             #
@@ -561,7 +560,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                             figs, captions, section=section,
                             image_format='svg')
                 print('%5.1f sec' % ((time.time() - t0),))
-            
+
             #
             # BEM
             #
@@ -684,9 +683,9 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                     this_evoked = mne.read_evokeds(fname_evoked, name)
                     # Define the time slices to include
                     times = sensor.get('times', [0.1, 0.2])
-                    if isinstance(times, str) and times=='peaks':                        
+                    if isinstance(times, str) and times == 'peaks':
                         times = _peak_times(this_evoked)
-                        times_memo[(fname_evoked,name)] = times
+                        times_memo[(fname_evoked, name)] = times
                     # Plot the responses
                     figs = this_evoked.plot_joint(
                         times, show=False, ts_args=dict(**time_kwargs),
@@ -780,7 +779,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                     size = source.get('size', (800, 600))
                     # Define the time slices to include
                     times = source.get('times', [0.1, 0.2])
-                    if isinstance(times, str) and times=='peaks':
+                    if isinstance(times, str) and times == 'peaks':
                         if (fname_evoked, name) in times_memo.keys():
                             times = times_memo[fname_evoked, name]
                             print('Local peak times obtained from '

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -799,8 +799,6 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                     if isinstance(times, str) and times == 'peaks':
                         if (fname_evoked, name) in times_memo.keys():
                             times = times_memo[fname_evoked, name]
-                            print('Local peak times obtained from '
-                                  'sensor analysis.')
                         else:
                             cov_name = _get_cov_name(p, subj,
                                                      source.get('cov'))

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -260,7 +260,8 @@ def _peak_times(evoked, noise_cov=None, max_peaks=5):
     '''Return times of prominent peaks from whitened global field power.'''
     # Whiten evoked data
     if noise_cov:
-        rank_dict = _triage_rank_sss(evoked.info, [noise_cov])[1][0]
+        with use_log_level('error'):
+            rank_dict = _triage_rank_sss(evoked.info, [noise_cov])[1][0]
         evoked = whiten_evoked(evoked, noise_cov, rank=rank_dict)
         thr = 1
         wht_str = 'Whitened '

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -10,6 +10,7 @@ import time
 import warnings
 
 import numpy as np
+from scipy.signal import find_peaks, peak_prominences
 
 import mne
 from mne import read_proj, read_epochs, find_events
@@ -674,8 +675,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                     assert isinstance(source, dict)
                     analysis = source['analysis']
                     name = source['name']
-                    times = source.get('times', [0.1, 0.2])
-                    # Load the inverse
+                    # Load the necessary data
                     inv_dir = op.join(p.work_dir, subj, p.inverse_dir)
                     fname_inv = op.join(inv_dir,
                                         safe_inserter(source['inv'], subj))
@@ -685,87 +685,105 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                     if not op.isfile(fname_inv):
                         print('    Missing inv: %s'
                               % op.basename(fname_inv), end='')
+                        continue
                     elif not op.isfile(fname_evoked):
                         print('    Missing evoked: %s'
                               % op.basename(fname_evoked), end='')
+                        continue
+                    # Generate the STC
+                    inv = mne.minimum_norm.read_inverse_operator(fname_inv)
+                    this_evoked = mne.read_evokeds(fname_evoked, name)
+                    title = ('%s: %s["%s"] (N=%d)'
+                             % (section, analysis, name, this_evoked.nave))
+                    stc = mne.minimum_norm.apply_inverse(
+                        this_evoked, inv,
+                        lambda2=source.get('lambda2', 1. / 9.),
+                        method=source.get('method', 'dSPM'))
+                    stc = abs(stc)
+                    # get clim using the reject_tmin <->reject_tmax
+                    stc_crop = stc.copy().crop(
+                        p.reject_tmin, p.reject_tmax)
+                    clim = source.get('clim', dict(kind='percent',
+                                                   lims=[82, 90, 98]))
+                    try:
+                        func = mne.viz._3d._limits_to_control_points
+                    except AttributeError:  # 0.20+
+                        clim = mne.viz._3d._process_clim(
+                            clim, 'viridis', transparent=True,
+                            data=stc_crop.data)['clim']
                     else:
-                        inv = mne.minimum_norm.read_inverse_operator(fname_inv)
-                        this_evoked = mne.read_evokeds(fname_evoked, name)
-                        title = ('%s: %s["%s"] (N=%d)'
-                                 % (section, analysis, name, this_evoked.nave))
-                        stc = mne.minimum_norm.apply_inverse(
-                            this_evoked, inv,
-                            lambda2=source.get('lambda2', 1. / 9.),
-                            method=source.get('method', 'dSPM'))
-                        stc = abs(stc)
-                        # get clim using the reject_tmin <->reject_tmax
-                        stc_crop = stc.copy().crop(
-                            p.reject_tmin, p.reject_tmax)
-                        clim = source.get('clim', dict(kind='percent',
-                                                       lims=[82, 90, 98]))
-                        try:
-                            func = mne.viz._3d._limits_to_control_points
-                        except AttributeError:  # 0.20+
-                            clim = mne.viz._3d._process_clim(
-                                clim, 'viridis', transparent=True,
-                                data=stc_crop.data)['clim']
+                        out = func(
+                            clim, stc_crop.data, 'viridis',
+                            transparent=True)  # dummy cmap
+                        if isinstance(out[0], (list, tuple, np.ndarray)):
+                            clim = out[0]  # old MNE
                         else:
-                            out = func(
-                                clim, stc_crop.data, 'viridis',
-                                transparent=True)  # dummy cmap
-                            if isinstance(out[0], (list, tuple, np.ndarray)):
-                                clim = out[0]  # old MNE
-                            else:
-                                clim = out[1]  # new MNE (0.17+)
-                            del out
-                            clim = dict(kind='value', lims=clim)
-                        assert isinstance(stc, (mne.SourceEstimate,
-                                                mne.VolSourceEstimate))
-                        bem, _, _, _ = _get_bem_src_trans(
-                            p, raw.info, subj, struc)
-                        is_usable = (isinstance(stc, mne.SourceEstimate) or
-                                     not bem['is_sphere'])
-                        if not is_usable:
-                            print('Only source estimates with individual '
-                                  'anatomy supported')
-                            break
-                        subjects_dir = mne.utils.get_subjects_dir(
-                            p.subjects_dir, raise_error=True)
-                        kwargs = dict(
-                            colormap=source.get('colormap', 'viridis'),
-                            transparent=source.get('transparent', True),
-                            clim=clim, subjects_dir=subjects_dir)
-                        imgs = list()
-                        size = source.get('size', (800, 600))
-                        if isinstance(stc, mne.SourceEstimate):
-                            with mlab_offscreen():
-                                brain = stc.plot(
-                                    hemi=source.get('hemi', 'split'),
-                                    views=source.get('views', ['lat', 'med']),
-                                    size=size,
-                                    foreground='k', background='w',
-                                    **kwargs)
-                                for t in times:
-                                    brain.set_time(t)
-                                    imgs.append(
-                                        trim_bg(brain.screenshot(), 255))
-                                brain.close()
-                        else:
-                            # XXX eventually plot_volume_source_estimtates
-                            # will have an intial_time arg...
-                            mode = source.get('mode', 'stat_map')
+                            clim = out[1]  # new MNE (0.17+)
+                        del out
+                        clim = dict(kind='value', lims=clim)
+                    assert isinstance(stc, (mne.SourceEstimate,
+                                            mne.VolSourceEstimate))
+                    bem, _, _, _ = _get_bem_src_trans(
+                        p, raw.info, subj, struc)
+                    is_usable = (isinstance(stc, mne.SourceEstimate) or
+                                 not bem['is_sphere'])
+                    if not is_usable:
+                        print('Only source estimates with individual '
+                              'anatomy supported')
+                        break
+                    subjects_dir = mne.utils.get_subjects_dir(
+                        p.subjects_dir, raise_error=True)
+                    kwargs = dict(
+                        colormap=source.get('colormap', 'viridis'),
+                        transparent=source.get('transparent', True),
+                        clim=clim, subjects_dir=subjects_dir)
+                    imgs = list()
+                    size = source.get('size', (800, 600))
+                    # Define the time slices to include
+                    times = source.get('times', [0.1, 0.2])
+                    if isinstance(times, str) and times=='peaks':
+                        data = stc.data
+                        npeaks = max(min(len(data)//3, 5), 1)
+                        # gfp = np.sqrt((data*data).mean(axis=0))
+                        gfp = data.std(axis=0)
+                        peaks = find_peaks(gfp)[0]
+                        prms = peak_prominences(gfp, peaks)[0]
+                        times = peaks[prms.argsort()[::-1]][:npeaks]
+                        times.sort()
+                        if not len(times):  # guarantee at least one point
+                            times = gfp.argmax()
+                        times = stc.times[times]
+                        print('Local peaks calculated at', times, 'sec.')
+                    # Create the STC plots
+                    if isinstance(stc, mne.SourceEstimate):
+                        with mlab_offscreen():
+                            brain = stc.plot(
+                                hemi=source.get('hemi', 'split'),
+                                views=source.get('views', ['lat', 'med']),
+                                size=size,
+                                foreground='k', background='w',
+                                **kwargs)
                             for t in times:
-                                fig = stc.copy().crop(t, t).plot(
-                                    src=inv['src'], mode=mode, show=False,
-                                    **kwargs,
-                                )
-                                fig.set_dpi(100.)
-                                fig.set_size_inches(*(np.array(size) / 100.))
-                                imgs.append(fig)
-                        captions = ['%2.3f sec' % t for t in times]
-                        report.add_slider_to_section(
-                            imgs, captions=captions, section=section,
-                            title=title, image_format='png')
+                                brain.set_time(t)
+                                imgs.append(
+                                    trim_bg(brain.screenshot(), 255))
+                            brain.close()
+                    else:
+                        # XXX eventually plot_volume_source_estimtates
+                        # will have an intial_time arg...
+                        mode = source.get('mode', 'stat_map')
+                        for t in times:
+                            fig = stc.copy().crop(t, t).plot(
+                                src=inv['src'], mode=mode, show=False,
+                                **kwargs,
+                            )
+                            fig.set_dpi(100.)
+                            fig.set_size_inches(*(np.array(size) / 100.))
+                            imgs.append(fig)
+                    captions = ['%2.3f sec' % t for t in times]
+                    report.add_slider_to_section(
+                        imgs, captions=captions, section=section,
+                        title=title, image_format='png')
                 print('%5.1f sec' % ((time.time() - t0),))
             else:
                 print('    %s skipped' % section)


### PR DESCRIPTION
A few comments:
- As @larsoner suggested, I used the global field power from the evoked object; for the source section, if that was already calculated for the sensor section, then I reused the 'times' for that particular analysis file / condition(name) combination (i.e. memoization)
- I went with the usual standard-deviation approach for gfp, but sqrt of the mean of the square is another way to go that takes into account mean activity across channels; I don't think the differences were that large, especially for the largest peaks
- There are other peak-finding functions, such as _find_peaks (and _process_times) in viz.utils; however, I think the prominence approach is more robust
- Per _process_times(), I assumed a modest number of peaks across the gfp, taking the most "prominent" and maintaining temporal order; however, peaks at negative event times are possible (but might still be of interest for a report because they give a sort of baseline)
- I tested this on the funloc subject #1; if there are alternative test data sets, please let me know and I can try them
- In line 503 or so of ._report.py in master, 'times' for the SNR report is defined but not used.  I didn't change this myself, though
- Finally, I'm not sure where to put tags such as [ci skip], or if that's even appropriate here.

