### PR TITLE
FIX: split-file issue with epoching and covariance processing (closes 287)

### DIFF
--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -121,6 +121,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                 ridx = inv_run
             else:
                 ridx = np.intersect1d(run_indices[si], inv_run)
+            # read in raw files
             raw_fnames = get_raw_fnames(p, subj, 'pca', False, False, ridx)
 
             raws = []
@@ -132,6 +133,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                 last_samps.append(raws[-1]._last_samps[-1])
             _fix_raw_eog_cals(raws)  # safe b/c cov only needs MEEG
             raw = concatenate_raws(raws)
+            # read in events
             events = _read_events(p, subj, ridx, raw)
             if p.pick_events_cov is not None:
                 old_count = sum(len(e) for e in events)
@@ -143,6 +145,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                 new_count = len(events)
                 print('  Using %s/%s events for %s'
                       % (new_count, old_count, op.basename(cov_name)))
+            # create epochs
             use_reject, use_flat = _restrict_reject_flat(reject, flat, raw)
             baseline = _get_baseline(p)
             epochs = Epochs(raw, events, event_id=None, tmin=baseline[0],

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -89,22 +89,18 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
         evoked_dir = op.join(p.work_dir, subj, p.inverse_dir)
         if not op.isdir(evoked_dir):
             os.mkdir(evoked_dir)
-
         # read in raw files
         raw_names = get_raw_fnames(p, subj, 'pca', False, False,
                                    run_indices[si])
-        # read in events
         first_samps = []
         last_samps = []
         for raw_fname in raw_names:
             raw = read_raw_fif(raw_fname, preload=False)
             first_samps.append(raw._first_samps[0])
             last_samps.append(raw._last_samps[-1])
-        # read in raw files
         raw = [read_raw_fif(fname, preload=False) for fname in raw_names]
         _fix_raw_eog_cals(raw)  # EOG epoch scales might be bad!
         raw = concatenate_raws(raw)
-
         # read in events
         events = _read_events(p, subj, run_indices[si], raw)
         new_sfreq = raw.info['sfreq'] / decim[si]
@@ -149,7 +145,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
             write_hdf5(hdf5_file, use_reject, overwrite=True)
         else:
             use_reject = _handle_dict(p.reject, subj)
-
+        # create epochs
         flat = _handle_dict(p.flat, subj)
         use_reject, use_flat = _restrict_reject_flat(use_reject, flat, raw)
         epochs = Epochs(raw, events, event_id=old_dict, tmin=p.tmin,

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -115,8 +115,8 @@ def _read_events(p, subj, ridx, raw):
                                % (fname,))
         events.append(these_events)
     if len(events) == 1 and len(raw._first_samps) > 1:  # for split raw
-        first_samps = np.array(raw._first_samps[0], ndmin=1)
-        last_samps = np.array(raw._last_samps[-1], ndmin=1)
+        first_samps = raw._first_samps[:1]
+        last_samps = raw._last_samps[-1:]
     else:
         first_samps = raw._first_samps
         last_samps = raw._last_samps

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -114,7 +114,7 @@ def _read_events(p, subj, ridx, raw):
             raise RuntimeError('Non-unique event samples found in %s'
                                % (fname,))
         events.append(these_events)
-    if len(events)==1 and len(raw._first_samps)>1:  # for split raw
+    if len(events) == 1 and len(raw._first_samps) > 1:  # for split raw
         first_samps = np.array(raw._first_samps[0], ndmin=1)
         last_samps = np.array(raw._last_samps[-1], ndmin=1)
     else:

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -114,7 +114,13 @@ def _read_events(p, subj, ridx, raw):
             raise RuntimeError('Non-unique event samples found in %s'
                                % (fname,))
         events.append(these_events)
-    events = concatenate_events(events, raw._first_samps, raw._last_samps)
+    if len(events)==1 and len(raw._first_samps)>1:  # for split raw
+        first_samps = np.array(raw._first_samps[0], ndmin=1)
+        last_samps = np.array(raw._last_samps[-1], ndmin=1)
+    else:
+        first_samps = raw._first_samps
+        last_samps = raw._last_samps
+    events = concatenate_events(events, first_samps, last_samps)
     if len(np.unique(events[:, 0])) != len(events):
         raise RuntimeError('Non-unique event samples found after '
                            'concatenation')

--- a/mnefun/_status.py
+++ b/mnefun/_status.py
@@ -42,7 +42,7 @@ def print_proc_status(p, subjects, structurals, analyses, run_indices):
             do_score = 'complete'
 
         # check if prebads created
-        if subj in p.prebad or op.isfile(_prebad(p, subj)):
+        if subj in p.mf_prebad or op.isfile(_prebad(p, subj)):
             prebads = 'complete'
 
         # check if coreg has been done

--- a/mnefun/_utils.py
+++ b/mnefun/_utils.py
@@ -49,12 +49,15 @@ def _cals(raw):
 
 def _get_baseline(p):
     """Helper to extract baseline from params."""
-    if p.baseline == 'individual':
+    if p.baseline is None:
+        return p.baseline
+    elif p.baseline == 'individual':
         baseline = (p.bmin, p.bmax)
     else:
         baseline = p.baseline
     # XXX this and some downstream stuff (e.g., tmin=-baseline[0]) won't work
     # for baseline=None, but we can fix that when someone needs it
+    # SMB (2020.04.20): added return None to skip baseline application.
     baseline = tuple(baseline)
     if baseline[0] is None:
         baseline = (p.tmin, baseline[1])


### PR DESCRIPTION
I tested this with 1) the usual funloc examples with non-split raw files and only a single run (subj_01 and subj_02); 2) a pseudo "subj_03" (also non-split), with a second run created by duplicating and clipping the original raw fif data; 3) a f2f subject with split raw files (2 file parts) encompassing a single run.  Note, I did not test it on a subject with split raw files AND multiple runs, but the code should allow for it.

Also corrected minor issues in other files, but please see commit notes.