### PR TITLE
ENH: Add every_other

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -454,6 +454,10 @@ must_match : list of int
     Indices from the original in_names that must match in event counts
     before collapsing. Should eventually be expanded to allow for
     ratio-based collapsing.
+every_other : bool
+    If True, in addition to standard averages / evoked data, averages will be
+    computed from every other trial, i.e., from even and odd trials separately.
+    This can help assess the SNR of the data.
 
 8. gen_covs
 -----------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,9 @@ Changelog
 
 2020
 ^^^^
+- 2020/04/28
+    Added ``every_other`` support for computing evoked data with
+    even and odd trials.
 - 2020/04/01
     Added peak-detection capability to reports for the sensor and source
     sections, using ``times='peaks'``. Peaks are based on whitened gfps.

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -84,6 +84,7 @@ epoching:
   out_names: [['All'], *in_names]
   out_numbers: [[1, 1, 1, 1], *in_numbers]
   must_match: [[], [0, 1]]
+  every_other: True
 
 covariance:
   cov_method: shrunk

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -216,14 +216,32 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
 
             # now make evoked for each out type
             evokeds = list()
-            for name in names:
-                this_e = e[name]
-                if len(this_e) > 0:
-                    evokeds.append(this_e.average())
-                    evokeds.append(this_e.standard_error())
+            n_standard = 0
+            kinds = ['standard']
+            if p.every_other:
+                kinds += ['even', 'odd']
+            for kind in kinds:
+                for name in names:
+                    this_e = e[name]
+                    if kind == 'even':
+                        this_e = this_e[::2]
+                    elif kind == 'odd':
+                        this_e = this_e[1::2]
+                    else:
+                        assert kind == 'standard'
+                    if len(this_e) > 0:
+                        ave = this_e.average()
+                        stde = this_e.standard_error()
+                        if kind != 'standard':
+                            ave.comment += ' %s' % (kind,)
+                            stde.comment += ' %s' % (kind,)
+                        evokeds.append(ave)
+                        evokeds.append(stde)
+                        if kind == 'standard':
+                            n_standard += 2
             write_evokeds(fn, evokeds)
-            naves = [str(n) for n in sorted(set([evoked.nave
-                                                 for evoked in evokeds]))]
+            naves = [str(n) for n in sorted(set([
+                evoked.nave for evoked in evokeds[:n_standard]]))]
             naves = ', '.join(naves)
             if p.disp_files:
                 print('      Analysis "%s": %s epochs / condition'

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -246,6 +246,7 @@ class Params(Frozen):
         self.epochs_prefix = 'All'
         self.reject_epochs_by_annot = True
         self.mf_prebad = dict()
+        self.every_other = False
         self.freeze()
         # Read static-able paraws from config file
         _set_static(self)

--- a/mnefun/data/canonical.yml
+++ b/mnefun/data/canonical.yml
@@ -115,6 +115,7 @@ epoching:
   out_names:
   out_numbers:
   must_match:
+  every_other:
 
 covariance:
   cov_method:

--- a/mnefun/tests/test_documented.py
+++ b/mnefun/tests/test_documented.py
@@ -19,11 +19,12 @@ def test_params(params):
     attrs.insert(attrs.index('list_dir'), 'report')
     assert set(attrs) == key_set
 
+
     # canonical document
     yvals = _flat_params_read(_CANONICAL_YAML_FNAME)
     # on Python3.7 we are guaranteed insertion order, so this should be okay
     yvals = list(yvals.keys())
-    assert set(yvals) == key_set
+    assert set(yvals) == key_set, 'Mismatch canonical<->Params'
     assert yvals == attrs
 
     # funloc has a correct subset

--- a/mnefun/tests/test_documented.py
+++ b/mnefun/tests/test_documented.py
@@ -19,7 +19,6 @@ def test_params(params):
     attrs.insert(attrs.index('list_dir'), 'report')
     assert set(attrs) == key_set
 
-
     # canonical document
     yvals = _flat_params_read(_CANONICAL_YAML_FNAME)
     # on Python3.7 we are guaranteed insertion order, so this should be okay


### PR DESCRIPTION
1. Forces `cov` to be provided when `peaks='times'` because the `rank` is needed to compute the GFP. I don't think this is too onerous anyway...
2. Adds `every_other` support, plus plotting in `report` if they're available in the Evoked

@NeuroLaunch can you try this on Alexis's data?

Closes #288