### PR TITLE
MRG, FIX: Fix errant picking of only data channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   global: OPENBLAS_NUM_THREADS=1
 
 python:
-  - "3.7"
+  - "3.8"
 
 install:
   # Install mnefun
-  - pip install numpy scipy matplotlib pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
+  - pip install --upgrade --binary-only=":all:" numpy scipy matplotlib pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
   - pip install -ve .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
 
 install:
   # Install mnefun
-  - pip install --upgrade --binary-only=":all:" numpy scipy matplotlib pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
+  - pip install --upgrade --only-binary=":all:" numpy scipy matplotlib
+  - pip install --upgrade pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
   - pip install -ve .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 install:
   # Install mnefun
-  - pip install numpy scipy matplotlib pyyaml patsy pytest pytest-cov pytest-sugar codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
+  - pip install numpy scipy matplotlib pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/archive/master.zip
   - pip install -ve .
 
 script:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ Changelog
 
 2020
 ^^^^
+- 2020/06/19
+    Fixed errant picking of only data channels in preprocessed raw data files.
+- 2020/05/26
+    Improved :class:`mne.Report` generation for comparing conditions by using
+    sliders and grouping by sensor types.
 - 2020/04/28
     Added ``every_other`` support for computing evoked data with
     even and odd trials.

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -230,8 +230,8 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
                     else:
                         assert kind == 'standard'
                     if len(this_e) > 0:
-                        ave = this_e.average()
-                        stde = this_e.standard_error()
+                        ave = this_e.average(picks='all')
+                        stde = this_e.standard_error(picks='all')
                         if kind != 'standard':
                             ave.comment += ' %s' % (kind,)
                             stde.comment += ' %s' % (kind,)

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -35,6 +35,7 @@ LJUST = 25
 SQRT_2 = np.sqrt(2)
 SQ2STR = '×√2'
 
+
 @contextmanager
 def report_context():
     """Create a context for making plt and mlab figures."""

--- a/mnefun/_ssp.py
+++ b/mnefun/_ssp.py
@@ -49,10 +49,9 @@ def _raw_LRFCP(raw_names, sfreq, l_freq, h_freq, n_jobs, n_jobs_resample,
     raw = list()
     for rn in raw_names:
         r = read_raw_fif(rn, preload=True, allow_maxshield='yes')
-        if pick:
-            r.pick_types(meg=True, eeg=True, eog=True, ecg=True, exclude=())
         r.load_bad_channels(bad_file, force=force_bads)
-        r.pick_types(meg=True, eeg=True, eog=True, ecg=True, exclude=[])
+        if pick:
+            r.pick_types(meg=True, eeg=True, eog=True, ecg=True, exclude=[])
         if _needs_eeg_average_ref_proj(r.info):
             r.set_eeg_reference(projection=True)
         if sfreq is not None:


### PR DESCRIPTION
FYI @NeuroLaunch if you rerun the `apply_ssp` and `write_epochs` steps, your `-epo.fif` and `-ave.fif` files should end up with the cHPI channels included. At least with the `funloc` data these changes make it work.