### PR TITLE
FIX: Adjust coil time window to allow for line harmonics

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ Changelog
 
 2020
 ^^^^
+- 2020/08/26:
+    Optimized window length for cHPI amplitude estimation by accounting for
+    line frequency and its harmonics. The window for a standard minimum cHPI
+    frequency of 83 Hz should now be longer (determined by the 60 Hz line
+    component) making head position estimation more robust.
 - 2020/07/21:
     Added support for ``cont_hp`` to allow high-pass filtering (in addition
     to existing low-pass filtering via ``cont_lp``; thereby allowing band-pass

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -125,7 +125,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
             rtmax = p.reject_tmax if p.reject_tmax is not None else p.tmax
             temp_epochs = Epochs(
                 raw, events, event_id=None, tmin=rtmin, tmax=rtmax,
-                baseline=_get_baseline(p), proj=p.epochs_proj, reject=None,
+                baseline=_get_baseline(p), proj=True, reject=None,
                 flat=None, preload=True, decim=decim[si],
                 reject_by_annotation=p.reject_epochs_by_annot)
             kwargs = dict()
@@ -150,7 +150,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
         use_reject, use_flat = _restrict_reject_flat(use_reject, flat, raw)
         epochs = Epochs(raw, events, event_id=old_dict, tmin=p.tmin,
                         tmax=p.tmax, baseline=_get_baseline(p),
-                        reject=use_reject, flat=use_flat, proj='delayed',
+                        reject=use_reject, flat=use_flat, proj=p.epochs_proj,
                         preload=True, decim=decim[si], on_missing=p.on_missing,
                         reject_tmin=p.reject_tmin, reject_tmax=p.reject_tmax,
                         reject_by_annotation=p.reject_epochs_by_annot)

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -72,7 +72,7 @@ def _report_good_hpi(report, fnames, p=None, subj=None):
     captions = list()
     for fname in fnames:
         fname, raw = _check_fname_raw(fname, p, subj)
-        fit_data, _ = _get_fit_data(raw, p, prefix='      ')
+        fit_data, _, _ = _get_fit_data(raw, p, prefix='      ')
         if fit_data is None:
             print('%s skipped, HPI count data not found (possibly '
                   'no params.*_limit values set?)' % (section,))
@@ -118,7 +118,7 @@ def _report_head_movement(report, fnames, p=None, subj=None, run_indices=None):
     captions = list()
     for fname in fnames:
         fname, raw = _check_fname_raw(fname, p, subj)
-        _, pos = _get_fit_data(raw, p, prefix='      ')
+        _, pos, _ = _get_fit_data(raw, p, prefix='      ')
         trans_to = _load_trans_to(p, subj, run_indices, raw)
         fig = plot_head_positions(pos=pos, destination=trans_to,
                                   info=raw.info, show=False)

--- a/mnefun/_sss.py
+++ b/mnefun/_sss.py
@@ -582,7 +582,7 @@ def _get_t_window(p, raw):
             info = raw.info
             if info['line_freq'] is not None:  # as in mne.chpi.py
                 line_freqs = np.arange(info['line_freq'], info['sfreq'] / 3.,
-                       info['line_freq'])
+                                       info['line_freq'])
             else:
                 line_freqs = np.array([60])   # SMB: should be safe to assume
         except RuntimeError:
@@ -594,7 +594,7 @@ def _get_t_window(p, raw):
             # of 727 Hz+) and 83 ms for 60 Hz line freq (w/ more typical coil
             # freqs of 83 Hz+).
             all_freqs = np.concatenate((hpi_freqs, line_freqs))
-            delta_freqs = [abs(b-a) for b in all_freqs for a in all_freqs \
+            delta_freqs = [abs(b - a) for b in all_freqs for a in all_freqs
                            if a != b]
             delta_freqs = np.array(delta_freqs)
             t_window = max(5. / all_freqs.min(), 1. / delta_freqs.min())

--- a/mnefun/_sss.py
+++ b/mnefun/_sss.py
@@ -579,9 +579,6 @@ def _get_t_window(p, raw):
     if t_window == 'auto':
         try:
             hpi_freqs, _, _ = _get_hpi_info(raw.info, verbose=False)
-            info = raw.info
-            line_freq = info['line_freq'] or 60
-            line_freqs = np.arange(line_freq, info['sfreq'] / 3., line_freq)
         except RuntimeError:
             t_window = 0.2
         else:
@@ -590,6 +587,9 @@ def _get_t_window(p, raw):
             # This will be 143 ms for 7 Hz spacing (e.g. w/ higher coil freqs
             # of 727 Hz+) and 83 ms for 60 Hz line freq (w/ more typical coil
             # freqs of 83 Hz+).
+            info = raw.info
+            line_freq = info['line_freq'] or 60
+            line_freqs = np.arange(line_freq, info['sfreq'] / 3., line_freq)
             all_freqs = np.concatenate((hpi_freqs, line_freqs))
             delta_freqs = np.diff(np.unique(all_freqs))
             t_window = max(5. / all_freqs.min(), 1. / delta_freqs.min())
@@ -783,10 +783,8 @@ def _head_pos_annot(p, subj, raw_fname, prefix='  '):
     from mne.annotations import _handle_meas_date
     printed = False
     if p is not None and p.movecomp is None:
-        head_pos = fit_data = None
+        fit_data = head_pos = t_window = None
     else:
-        # t_window = _get_t_window(p, raw)    SMB 20.08.20: incorp. below
-        # do the coil counts
         fit_data, head_pos, t_window = _get_fit_data(raw, p, prefix)
 
     # do the annotations


### PR DESCRIPTION
This pull request fixes an SSS processing issue with poor coil amplitude fits (goodness-of-fits << 0.90) when coil frequencies are too close to harmonics of the line frequency.
- Removed a redundant `t_window` calculation in _head_pos_annot()
- Added option to return `t_window` value from call to _get_fit_data(), for backward compatibility
- Fixed an occasional problem where raw.time_as_index() returns a negative value other than -1 (the mne-python method shouldn't do this, but the fix here in mnefun should not cause conflicts)
- Caveat: The `t_window` value used for filter_chpi() and other routines may not be the same as `t_window` calculated for _get_fit_data(); this seems not be a problem
- Code was tested with 1 subject having high coil frequencies (700-900+ Hz) and 1 subject having more typical frequencies (83-323 Hz).