### PR TITLE
ENH: Add make_dipole_projectors

### DIFF
--- a/mnefun/__init__.py
+++ b/mnefun/__init__.py
@@ -14,7 +14,7 @@ from ._sss import run_sss_command, run_sss_positions, info_sss_basis, \
     compute_good_coils, check_sws
 from ._viz import plot_reconstruction, plot_chpi_snr_raw, plot_good_coils, \
     clean_brain, plot_colorbar, discretize_cmap
-from ._utils import make_montage, compute_auc
+from ._utils import make_montage, compute_auc, make_dipole_projectors
 from ._stats import (anova_time, hotelling_t2, hotelling_t2_baseline,
                      partial_conjunction)
 from ._viz import trim_bg

--- a/mnefun/_inverse.py
+++ b/mnefun/_inverse.py
@@ -7,7 +7,7 @@ import numpy as np
 from mne import (read_label, read_labels_from_annot, read_source_spaces, Label,
                  SourceEstimate, BiHemiLabel, read_surface, read_epochs,
                  read_cov, read_forward_solution, convert_forward_solution,
-                 pick_types_forward, spatial_src_connectivity)
+                 pick_types_forward)
 from mne.cov import regularize
 from mne.minimum_norm import make_inverse_operator, write_inverse_operator
 from mne.stats import spatio_temporal_cluster_1samp_test
@@ -17,6 +17,10 @@ from ._cov import _compute_rank
 from ._paths import (get_epochs_evokeds_fnames, safe_inserter,
                      get_cov_fwd_inv_fnames)
 
+try:
+    from mne import spatial_src_adjacency
+except ImportError:
+    from mne import spatial_src_connectivity as spatial_src_adjacency
 
 def gen_inverses(p, subjects, run_indices):
     """Generate inverses.
@@ -323,7 +327,7 @@ def extract_roi(stc, src, label=None, thresh=0.5):
 
     # Get contiguous vertices within 50%
     threshold = max_val * thresh
-    connectivity = spatial_src_connectivity(src, verbose='error')  # holes
+    connectivity = spatial_src_adjacency(src, verbose='error')  # holes
     _, clusters, _, _ = spatio_temporal_cluster_1samp_test(
         np.array([stc.data]), threshold, n_permutations=1,
         stat_fun=lambda x: x.mean(0), tail=1,

--- a/mnefun/_inverse.py
+++ b/mnefun/_inverse.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from mne import spatial_src_connectivity as spatial_src_adjacency
 
+
 def gen_inverses(p, subjects, run_indices):
     """Generate inverses.
 


### PR DESCRIPTION
@mdclarke can you see if this works with your data? This script for me:

<details>

```
import numpy as np
import mne
from mnefun import make_dipole_projectors

data_path = mne.datasets.sample.data_path()
subjects_dir = data_path + '/subjects'
fname_ave = data_path + '/MEG/sample/sample_audvis-ave.fif'
fname_cov = data_path + '/MEG/sample/sample_audvis-cov.fif'
fname_fwd = data_path + '/MEG/sample/sample_audvis-meg-eeg-oct-6-fwd.fif'
fname_bem = subjects_dir + '/sample/bem/sample-5120-5120-5120-bem-sol.fif'
fname_trans = data_path + '/MEG/sample/sample_audvis_raw-trans.fif'
evoked = mne.read_evokeds(fname_ave, condition='Right Auditory',
                          baseline=(None, 0))
# evoked.pick_types(meg=True, eeg=False, exclude=())
print(evoked)
fwd = mne.read_forward_solution(fname_fwd)
cov = mne.read_cov(fname_cov)
dipoles, residual = mne.inverse_sparse.mixed_norm(
    evoked, fwd, cov, alpha=30, loose=0., n_mxne_iter=5,
    return_as_dipoles=True, return_residual=True, verbose=True)
pos = np.array([dip.pos[0] for dip in dipoles])
ori = np.array([dip.ori[0] for dip in dipoles])
projs = make_dipole_projectors(
    evoked.info, pos, ori, fname_bem, fname_trans)
assert len(projs) == 2 * len(pos)  # MEG and EEG separate
evoked.apply_proj().plot()
# 
residual.plot()
evoked.add_proj(projs).apply_proj().plot()
```

</details>

Produces:

![Screenshot from 2020-09-24 08-49-24](https://user-images.githubusercontent.com/2365790/94147147-eb779200-fe42-11ea-9ac6-6c8b1cfe7347.png)

![Screenshot from 2020-09-24 08-49-26](https://user-images.githubusercontent.com/2365790/94147152-edd9ec00-fe42-11ea-9a46-80ca529d4e27.png)
