### PR TITLE
proportion → number

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -320,7 +320,7 @@ auto_bad_reject : str | dict | None
 auto_bad_flat : dict | None
     Flat threshold for auto bad.
 auto_bad_eeg_thresh : float | None
-    If more than this proportion of EEG channels is automatically marked bad,
+    If more than this number of EEG channels is automatically marked bad,
     an error will be raised. This helps ensure that not too many channels
     are marked as bad.
 auto_bad_meg_thresh : float | None

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -319,11 +319,11 @@ auto_bad_reject : str | dict | None
     http://autoreject.github.io/ for details.
 auto_bad_flat : dict | None
     Flat threshold for auto bad.
-auto_bad_eeg_thresh : float | None
+auto_bad_eeg_thresh : int | None
     If more than this number of EEG channels is automatically marked bad,
     an error will be raised. This helps ensure that not too many channels
     are marked as bad.
-auto_bad_meg_thresh : float | None
+auto_bad_meg_thresh : int | None
     Same as above but for MEG.
 
 ``preprocessing: ssp``: SSP creation parameters


### PR DESCRIPTION
The docs say "proportion" but what is actually compared is just the raw number, as far as I can tell from the code here:

https://github.com/LABSN/mnefun/blob/4885000a57fb61f0ea3cd01e65dcd327faf557f5/mnefun/_ssp.py#L200-L208

I think this is the right fix given that the default is "10" (i.e., not a proportion), but LMK if you'd rather I leave the docs alone and fix the code / default.