### PR TITLE
ENH: Allow float decim as dest

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -444,9 +444,11 @@ bmin : float
     Lower limit for baseline compensation.
 bmax : float
     Upper limit for baseline compensation.
-decim : int
+decim : int | float | list
     Amount to decimate the data after filtering when epoching data
     (e.g., a factor of 5 on 1000 Hz data yields 200 Hz data).
+    If a float is used, it should be the destination sample rate
+    (e.g., a value of 200. with 1000 Hz data will use  decim=5).
 epochs_type : str | list
     Can be 'fif', 'mat', or a list containing both.
 match_fun : callable | None

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,8 @@ Changelog
 
 2020
 ^^^^
+- 2020/12/18:
+    Added ``float`` support for ``params.decim``.
 - 2020/11/02:
     Added :func:`mnefun.repeat_coreg`.
 - 2020/09/28:

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -17,7 +17,7 @@ from mne.viz import plot_cov
 from ._paths import get_epochs_evokeds_fnames, get_raw_fnames, safe_inserter
 from ._scoring import _read_events
 from ._utils import (get_args, _get_baseline, _restrict_reject_flat,
-                     _fix_raw_eog_cals, _handle_dict)
+                     _fix_raw_eog_cals, _handle_dict, _handle_decim)
 
 
 def _compute_rank(p, subj, run_indices):
@@ -141,6 +141,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                 last_samps.append(raws[-1]._last_samps[-1])
             _fix_raw_eog_cals(raws)  # safe b/c cov only needs MEEG
             raw = concatenate_raws(raws)
+            this_decim = _handle_decim(decim, raw.info['sfreq'])
             # read in events
             events = _read_events(p, subj, ridx, raw)
             if p.pick_events_cov is not None:
@@ -160,7 +161,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                             tmax=baseline[1], baseline=(None, None),
                             proj=False,
                             reject=use_reject, flat=use_flat, preload=True,
-                            decim=decim[si],
+                            decim=this_decim,
                             verbose='error',  # ignore decim-related warnings
                             on_missing=p.on_missing,
                             reject_by_annotation=p.reject_epochs_by_annot)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -482,7 +482,7 @@ def do_processing(p, fetch_raw=False, do_score=False, push_raw=False,
         decim = [decim] * len(p.subjects)
     assert len(decim) == n_subj_orig
     decim = np.array(decim)
-    assert decim.dtype.char in 'il', decim.dtype
+    assert decim.dtype.char in 'ild', (decim.dtype.char, decim.dtype)
     assert decim.shape == (len(p.subjects),), decim.shape
     decim = decim[sinds]
 

--- a/mnefun/_utils.py
+++ b/mnefun/_utils.py
@@ -80,6 +80,19 @@ def _handle_dict(entry, subj):
     return out
 
 
+def _handle_decim(decim, sfreq):
+    decim = np.array(decim)
+    assert decim.shape == ()
+    if decim.dtype.char in 'il':
+        return decim
+    else:
+        # float
+        assert decim.dtype.char == 'd', decim.dtype.char
+        got_decim = int(round(sfreq / decim))
+        assert np.isclose(sfreq / got_decim, decim), (sfreq, decim, got_decim)
+        return got_decim
+
+
 def _safe_remove(fnames):
     if isinstance(fnames, str):
         fnames = [fnames]


### PR DESCRIPTION
Useful for @ktavabi who has data sampled at 1800 and 1200 Hz, allowing `decim=300.` is a lot nicer than having to pass a list of decim values. @nordme @mdclarke can you look as well, as it might be relevant to you, too? Some of your data might be this way, not sure.