### PR TITLE
ENH: Add eSSS

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -262,9 +262,10 @@ sss_format : str
     Deprecated. SSS numerical format when using MaxFilter.
 mf_args : str
     Deprecated. Extra arguments for MF SSS.
-erm_proj_as_esss : bool
+cont_as_esss : bool
     If True (default False), use eSSS to improve the external basis estimate
-    using ``proj_nums[2]``. Only supported when Python is used for SSS.
+    using continuous empty-room projectors (``proj_nums[2]``).
+    Only supported when Python is used for SSS.
 
 
 4. do_ch_fix
@@ -351,15 +352,6 @@ proj_nums : list | dict
 
     If you want just blink and HEOG, you can use a list of 4 lists instead of
     5 (or 3).
-erm_proj_hp_cut : float | None
-    High-pass cutoff (e.g., 0.5 Hz) to use for empty-room projector
-    calculations.
-erm_proj_lp_cut : float | None
-    Low-pass cutoff (e.g. 40 Hz) to use for empty-room projector calculations.
-erm_proj_reject : dict | None
-    Rejection parameters for empty-room projection calculations.
-    None (default) will use ``params.reject``.
-    This likely needs to be set when ``erm_proj_as_esss=True``.
 proj_sfreq : float | None
     The sample freq to use for calculating projectors. Useful since
     time points are not independent following low-pass. Also saves
@@ -421,8 +413,17 @@ get_projs_from : list of int | dict
     Indices for runs to get projects from.
 cont_hp : float
     Highpass to use for continuous ERM projectors (default None).
+cont_hp_trans : float | None
+    Highpass transition bandwidth to use for continuous ERM projectors
+    (default 0.5).
 cont_lp : float
     Lowpass to use for continuous ERM projectors (default 5).
+cont_lp_trans : float | None
+    Lowpass transition bandwidth for continuous ERM projectors (default None).
+cont_reject : dict | None
+    Rejection parameters for continuous empty-room projection calculations.
+    None (default) will use ``params.reject``.
+    This likely needs to be set when ``cont_as_esss=True``.
 plot_drop_logs : bool
     If True, plot drop logs after preprocessing.
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -262,6 +262,9 @@ sss_format : str
     Deprecated. SSS numerical format when using MaxFilter.
 mf_args : str
     Deprecated. Extra arguments for MF SSS.
+erm_proj_as_esss : bool
+    If True (default False), use eSSS to improve the external basis estimate
+    using ``proj_nums[2]``. Only supported when Python is used for SSS.
 
 
 4. do_ch_fix
@@ -348,6 +351,15 @@ proj_nums : list | dict
 
     If you want just blink and HEOG, you can use a list of 4 lists instead of
     5 (or 3).
+erm_proj_hp_cut : float | None
+    High-pass cutoff (e.g., 0.5 Hz) to use for empty-room projector
+    calculations.
+erm_proj_lp_cut : float | None
+    Low-pass cutoff (e.g. 40 Hz) to use for empty-room projector calculations.
+erm_proj_reject : dict | None
+    Rejection parameters for empty-room projection calculations.
+    None (default) will use ``params.reject``.
+    This likely needs to be set when ``erm_proj_as_esss=True``.
 proj_sfreq : float | None
     The sample freq to use for calculating projectors. Useful since
     time points are not independent following low-pass. Also saves

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,9 @@ Changelog
 2020
 ^^^^
 - 2020/12/18:
+    Added ``erm_proj_as_esss``, ``erm_proj_lp_cut``, and ``erm_proj_hp_cut``
+    to support using eSSS for empty-room projectors.
+- 2020/12/18:
     Added ``float`` support for ``params.decim``.
 - 2020/11/02:
     Added :func:`mnefun.repeat_coreg`.

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -44,7 +44,7 @@ preprocessing:
     tsss_dur: 60.
     st_correlation: 0.98
     trans_to: twa
-    erm_proj_as_esss: True
+    cont_as_esss: True
   filtering:
     lp_cut: 50
     lp_trans: 10
@@ -52,13 +52,14 @@ preprocessing:
     fir_design: firwin
     phase: zero
   ssp:
+    cont_hp: 20
+    cont_hp_trans: 2
+    cont_lp: 40
+    cont_lp_trans: 2
     proj_nums: {
-      subj_01: [[2, 2, 0], [1, 1, 3], [8, 8, 0], [1, 1, 0], [1, 1, 0]],
-      subj_02: [[2, 2, 0], [1, 1, 2], [8, 8, 0]],
+      subj_01: [[2, 2, 0], [1, 1, 3], [3, 3, 0], [1, 1, 0], [1, 1, 0]],
+      subj_02: [[2, 2, 0], [1, 1, 2], [3, 3, 0]],
       }
-    erm_proj_lp_cut: 20
-    erm_proj_lp_cut: 40
-    erm_proj_reject: {'mag': 5.e-11, 'grad': 1.5e-9}
     proj_sfreq: 200
     proj_meg: combined
     eog_f_lims: [1, 10]
@@ -108,7 +109,7 @@ report:
   sensor: [
     {analysis: All, name: All, times: 'peaks', proj: False},
     {analysis: All, name: All, times: 'peaks'},
-    {analysis: All, name: All, times: 'peaks', proj: 'reconstruct'},
+    #{analysis: All, name: All, times: 'peaks', proj: 'reconstruct'},
     ]
   source: {analysis: All, name: All, inv: '%s-50-sss-meg-eeg-free-inv.fif',
            times: 'peaks', views: lat, size: [800, 400]}

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -44,6 +44,7 @@ preprocessing:
     tsss_dur: 60.
     st_correlation: 0.98
     trans_to: twa
+    erm_proj_as_esss: True
   filtering:
     lp_cut: 50
     lp_trans: 10
@@ -52,9 +53,12 @@ preprocessing:
     phase: zero
   ssp:
     proj_nums: {
-      subj_01: [[2, 2, 0], [1, 1, 3], [0, 0, 0], [1, 1, 0], [1, 1, 0]],
-      subj_02: [[2, 2, 0], [1, 1, 2], [0, 0, 0]],
+      subj_01: [[2, 2, 0], [1, 1, 3], [8, 8, 0], [1, 1, 0], [1, 1, 0]],
+      subj_02: [[2, 2, 0], [1, 1, 2], [8, 8, 0]],
       }
+    erm_proj_lp_cut: 20
+    erm_proj_lp_cut: 40
+    erm_proj_reject: {'mag': 5.e-11, 'grad': 1.5e-9}
     proj_sfreq: 200
     proj_meg: combined
     eog_f_lims: [1, 10]

--- a/examples/funloc/funloc_params.yml
+++ b/examples/funloc/funloc_params.yml
@@ -109,7 +109,7 @@ report:
   sensor: [
     {analysis: All, name: All, times: 'peaks', proj: False},
     {analysis: All, name: All, times: 'peaks'},
-    #{analysis: All, name: All, times: 'peaks', proj: 'reconstruct'},
+    {analysis: All, name: All, times: 'peaks', proj: 'reconstruct'},
     ]
   source: {analysis: All, name: All, inv: '%s-50-sss-meg-eeg-free-inv.fif',
            times: 'peaks', views: lat, size: [800, 400]}

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -267,6 +267,10 @@ class Params(Frozen):
         self.every_other = False
         self.cov_rank_method = 'estimate_rank'
         self.epochs_proj = True
+        self.erm_proj_as_esss = False
+        self.erm_proj_lp_cut = None
+        self.erm_proj_hp_cut = None
+        self.erm_proj_reject = None
         self.freeze()
         # Read static-able paraws from config file
         _set_static(self)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -110,7 +110,7 @@ class Params(Frozen):
         self.cont_hp = None
         self.cont_hp_trans = 0.5
         self.cont_lp = 5.
-        self.cont_lp_trans = None
+        self.cont_lp_trans = 0.5
         self.hp_cut = hp_cut
         self.lp_cut = lp_cut
         self.hp_trans = hp_trans

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -108,11 +108,13 @@ class Params(Frozen):
         self.n_jobs_resample = n_jobs_resample
         self.filter_length = filter_length
         self.cont_hp = None
+        self.cont_hp_trans = 0.5
         self.cont_lp = 5.
-        self.lp_cut = lp_cut
+        self.cont_lp_trans = None
         self.hp_cut = hp_cut
-        self.lp_trans = lp_trans
+        self.lp_cut = lp_cut
         self.hp_trans = hp_trans
+        self.lp_trans = lp_trans
         self.phase = 'zero-double'
         self.fir_window = 'hann'
         self.fir_design = 'firwin2'
@@ -267,10 +269,8 @@ class Params(Frozen):
         self.every_other = False
         self.cov_rank_method = 'estimate_rank'
         self.epochs_proj = True
-        self.erm_proj_as_esss = False
-        self.erm_proj_lp_cut = None
-        self.erm_proj_hp_cut = None
-        self.erm_proj_reject = None
+        self.cont_as_esss = False
+        self.cont_reject = None
         self.freeze()
         # Read static-able paraws from config file
         _set_static(self)

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -476,7 +476,7 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                                    show=False))
                 if any(proj_nums[2]):  # ERM
                     if 'preproc_cont-proj.fif' in proj_files:
-                        if p.erm_proj_as_esss:
+                        if p.cont_as_esss:
                             extra = ' (eSSS)'
                             use_info = raw.info
                         else:

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -476,10 +476,16 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                                                    show=False))
                 if any(proj_nums[2]):  # ERM
                     if 'preproc_cont-proj.fif' in proj_files:
-                        comments.append('Continuous')
+                        if p.erm_proj_as_esss:
+                            extra = ' (eSSS)'
+                            use_info = raw.info
+                        else:
+                            extra = ''
+                            use_info = sss_info
+                        comments.append('Continuous%s' % (extra,))
                         figs.append(_proj_fig(op.join(
                             p.work_dir, subj, p.pca_dir,
-                            'preproc_cont-proj.fif'), sss_info,
+                            'preproc_cont-proj.fif'), use_info,
                             proj_nums[2], p.proj_meg, 'ERM', None,
                             duration))
                 if any(proj_nums[0]):  # ECG

--- a/mnefun/_ssp.py
+++ b/mnefun/_ssp.py
@@ -331,11 +331,12 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 assert proj_nums[2][2] == 0  # no EEG projectors for ERM
                 if len(empty_names) == 0:
                     raise RuntimeError('Cannot compute empty-room projectors '
-                                    'from continuous raw data')
+                                       'from continuous raw data')
                 if p.disp_files:
                     print('    Computing continuous projectors using ERM.')
                 # Use empty room(s), but processed the same way
-                projs.extend(_compute_erm_proj(p, subj, 'sss', projs, bad_file))
+                projs.extend(
+                    _compute_erm_proj(p, subj, 'sss', projs, bad_file))
             else:
                 cont_proj = op.join(pca_dir, 'preproc_cont-proj.fif')
                 _safe_remove(cont_proj)

--- a/mnefun/_ssp.py
+++ b/mnefun/_ssp.py
@@ -43,15 +43,20 @@ def _raw_LRFCP(raw_names, sfreq, l_freq, h_freq, n_jobs, n_jobs_resample,
                skip_by_annotation=('bad', 'skip')):
     """Helper to load, filter, concatenate, then project raw files"""
     from mne.io.proj import _needs_eeg_average_ref_proj
+    from ._sss import _read_raw_prebad
     if isinstance(raw_names, str):
         raw_names = [raw_names]
     if disp_files:
         print(f'    Loading and filtering {len(raw_names)} '
               f'file{_pl(raw_names)}.')
     raw = list()
-    for rn in raw_names:
-        r = read_raw_fif(rn, preload=True, allow_maxshield='yes')
-        r.load_bad_channels(bad_file, force=force_bads)
+    for ri, rn in enumerate(raw_names):
+        if isinstance(bad_file, tuple):
+            p, subj, kwargs = bad_file
+            r = _read_raw_prebad(p, subj, rn, disp=(ri == 0), **kwargs)
+        else:
+            r = read_raw_fif(rn, preload=True, allow_maxshield='yes')
+            r.load_bad_channels(bad_file, force=force_bads)
         if pick:
             r.pick_types(meg=True, eeg=True, eog=True, ecg=True, exclude=[])
         if _needs_eeg_average_ref_proj(r.info):
@@ -87,6 +92,72 @@ def compute_proj_wrap(epochs, average, **kwargs):
         return compute_proj_epochs(epochs, **kwargs)
 
 
+def _get_pca_dir(p, subj):
+    pca_dir = op.join(p.work_dir, subj, p.pca_dir)
+    if not op.isdir(pca_dir):
+        os.mkdir(pca_dir)
+    return pca_dir
+
+
+def _get_proj_kwargs(p):
+    proj_kwargs = dict()
+    p_sl = 1
+    if 'meg' not in get_args(compute_proj_raw):
+        if p.proj_meg != 'separate':
+            raise RuntimeError('MNE is too old for proj_meg option')
+    else:
+        proj_kwargs['meg'] = p.proj_meg
+        if p.proj_meg == 'combined':
+            p_sl = 2
+    return proj_kwargs, p_sl
+
+
+def _compute_erm_proj(p, subj, projs, kind, bad_file, remove_existing=False,
+                      disp_files=None):
+    disp_files = p.disp_files if disp_files is None else disp_files
+    assert kind in ('sss', 'raw')
+    proj_nums = _proj_nums(p, subj)
+    proj_kwargs, p_sl = _get_proj_kwargs(p)
+    empty_names = get_raw_fnames(p, subj, kind, 'only')
+    fir_kwargs, _ = _get_fir_kwargs(p.fir_design)
+    flat = _handle_dict(p.flat, subj)
+    raw = _raw_LRFCP(
+        raw_names=empty_names, sfreq=p.proj_sfreq,
+        l_freq=p.erm_proj_hp_cut, h_freq=p.erm_proj_lp_cut,
+        n_jobs=p.n_jobs_fir, apply_proj=not remove_existing,
+        n_jobs_resample=p.n_jobs_resample, projs=projs,
+        bad_file=bad_file, disp_files=disp_files, method='fir',
+        filter_length=p.filter_length, force_bads=True,
+        l_trans=p.hp_trans, h_trans=p.lp_trans,
+        phase=p.phase, fir_window=p.fir_window,
+        skip_by_annotation='edge', **fir_kwargs)
+    if remove_existing:
+        raw.del_proj()
+    raw.filter(p.cont_hp, p.cont_lp, n_jobs=p.n_jobs_fir, method='fir',
+               filter_length=p.filter_length, h_trans_bandwidth=0.5,
+               fir_window=p.fir_window, phase=p.phase,
+               skip_by_annotation='edge', **fir_kwargs)
+    if projs:
+        raw.add_proj(projs)
+    raw.apply_proj()
+    raw.pick_types(meg=True, eeg=False, exclude=())  # remove EEG
+    use_reject = p.erm_proj_reject
+    if use_reject is None:
+        use_reject = p.reject
+    use_reject, use_flat = _restrict_reject_flat(
+        _handle_dict(use_reject, subj), flat, raw)
+    pr = compute_proj_raw(raw, duration=1, n_grad=proj_nums[2][0],
+                          n_mag=proj_nums[2][1], n_eeg=proj_nums[2][2],
+                          reject=use_reject, flat=use_flat,
+                          n_jobs=p.n_jobs_mkl, **proj_kwargs)
+    assert len(pr) == np.sum(proj_nums[2][::p_sl])
+    # When doing eSSS it's a bit weird to put this in pca_dir but why not
+    pca_dir = _get_pca_dir(p, subj)
+    cont_proj = op.join(pca_dir, 'preproc_cont-proj.fif')
+    write_proj(cont_proj, pr)
+    return pr
+
+
 def do_preprocessing_combined(p, subjects, run_indices):
     """Do preprocessing on all raw files together.
 
@@ -109,7 +180,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
         if p.disp_files:
             print('  Preprocessing subject %g/%g (%s).'
                   % (si + 1, len(subjects), subj))
-        pca_dir = op.join(p.work_dir, subj, p.pca_dir)
+        pca_dir = _get_pca_dir(p, subj)
         bad_file = get_bad_fname(p, subj, check_exists=False)
 
         # Create SSP projection vectors after marking bad channels
@@ -227,11 +298,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
         ecg_eve = op.join(pca_dir, 'preproc_ecg-eve.fif')
         ecg_epo = op.join(pca_dir, 'preproc_ecg-epo.fif')
         ecg_proj = op.join(pca_dir, 'preproc_ecg-proj.fif')
-        cont_proj = op.join(pca_dir, 'preproc_cont-proj.fif')
         all_proj = op.join(pca_dir, 'preproc_all-proj.fif')
-
-        if not op.isdir(pca_dir):
-            os.mkdir(pca_dir)
 
         get_projs_from = _handle_dict(p.get_projs_from, subj)
         if get_projs_from is None:
@@ -253,60 +320,25 @@ def do_preprocessing_combined(p, subjects, run_indices):
         if p.proj_extra is not None:
             if p.disp_files:
                 print('    Adding extra projectors from "%s".' % p.proj_extra)
-            extra_proj = op.join(pca_dir, p.proj_extra)
-            projs = read_proj(extra_proj)
+            projs.extend(read_proj(op.join(pca_dir, p.proj_extra)))
 
-        extra_proj = dict()
-        p_sl = 1
-        if 'meg' not in get_args(compute_proj_raw):
-            if p.proj_meg != 'separate':
-                raise RuntimeError('MNE is too old for proj_meg option')
-        else:
-            extra_proj['meg'] = p.proj_meg
-            if p.proj_meg == 'combined':
-                p_sl = 2
-
+        proj_kwargs, p_sl = _get_proj_kwargs(p)
         #
         # Calculate and apply ERM projectors
         #
-        if any(proj_nums[2]):
-            assert proj_nums[2][2] == 0  # no EEG projectors for ERM
-            if len(empty_names) >= 1:
+        if not p.erm_proj_as_esss:
+            if any(proj_nums[2]):
+                assert proj_nums[2][2] == 0  # no EEG projectors for ERM
+                if len(empty_names) == 0:
+                    raise RuntimeError('Cannot compute empty-room projectors '
+                                    'from continuous raw data')
                 if p.disp_files:
                     print('    Computing continuous projectors using ERM.')
                 # Use empty room(s), but processed the same way
-                raw = _raw_LRFCP(
-                    raw_names=empty_names, sfreq=p.proj_sfreq,
-                    l_freq=None, h_freq=None, n_jobs=p.n_jobs_fir,
-                    n_jobs_resample=p.n_jobs_resample, projs=projs,
-                    bad_file=bad_file, disp_files=p.disp_files, method='fir',
-                    filter_length=p.filter_length, force_bads=True,
-                    l_trans=p.hp_trans, h_trans=p.lp_trans,
-                    phase=p.phase, fir_window=p.fir_window,
-                    skip_by_annotation='edge', **fir_kwargs)
+                projs.extend(_compute_erm_proj(p, subj, 'sss', projs, bad_file))
             else:
-                if p.disp_files:
-                    print('    Computing continuous projectors using data.')
-                raw = raw_orig.copy()
-            raw.filter(p.cont_hp, p.cont_lp, n_jobs=p.n_jobs_fir, method='fir',
-                       filter_length=p.filter_length, h_trans_bandwidth=0.5,
-                       fir_window=p.fir_window, phase=p.phase,
-                       skip_by_annotation='edge', **fir_kwargs)
-            raw.add_proj(projs)
-            raw.apply_proj()
-            raw.pick_types(meg=True, eeg=False, exclude=())  # remove EEG
-            use_reject, use_flat = _restrict_reject_flat(
-                _handle_dict(p.reject, subj), flat, raw)
-            pr = compute_proj_raw(raw, duration=1, n_grad=proj_nums[2][0],
-                                  n_mag=proj_nums[2][1], n_eeg=proj_nums[2][2],
-                                  reject=use_reject, flat=use_flat,
-                                  n_jobs=p.n_jobs_mkl, **extra_proj)
-            assert len(pr) == np.sum(proj_nums[2][::p_sl])
-            write_proj(cont_proj, pr)
-            projs.extend(pr)
-            del raw
-        else:
-            _safe_remove(cont_proj)
+                cont_proj = op.join(pca_dir, 'preproc_cont-proj.fif')
+                _safe_remove(cont_proj)
 
         #
         # Calculate and apply the ECG projectors
@@ -348,7 +380,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 pr = compute_proj_wrap(
                     ecg_epochs, p.proj_ave, n_grad=proj_nums[0][0],
                     n_mag=proj_nums[0][1], n_eeg=proj_nums[0][2],
-                    desc_prefix=desc_prefix, **extra_proj)
+                    desc_prefix=desc_prefix, **proj_kwargs)
                 assert len(pr) == np.sum(proj_nums[0][::p_sl])
                 write_proj(ecg_proj, pr)
                 projs.extend(pr)
@@ -367,7 +399,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
         for idx, kind in ((1, 'EOG'), (3, 'HEOG'), (4, 'VEOG')):
             _compute_add_eog(
                 p, subj, raw_orig, projs, proj_nums[idx], kind, pca_dir,
-                flat, extra_proj, old_kwargs, p_sl)
+                flat, proj_kwargs, old_kwargs, p_sl)
         del proj_nums
 
         # save the projectors
@@ -415,7 +447,7 @@ def _proj_nums(p, subj):
 
 
 def _compute_add_eog(p, subj, raw_orig, projs, eog_nums, kind, pca_dir,
-                     flat, extra_proj, old_kwargs, p_sl):
+                     flat, proj_kwargs, old_kwargs, p_sl):
     assert kind in ('EOG', 'HEOG', 'VEOG')
     bk = dict(EOG='blink').get(kind, kind.lower())
     eog_eve = op.join(pca_dir, f'preproc_{bk}-eve.fif')
@@ -456,7 +488,7 @@ def _compute_add_eog(p, subj, raw_orig, projs, eog_nums, kind, pca_dir,
             pr = compute_proj_wrap(
                 eog_epochs, p.proj_ave, n_grad=eog_nums[0],
                 n_mag=eog_nums[1], n_eeg=eog_nums[2],
-                desc_prefix=desc_prefix, **extra_proj)
+                desc_prefix=desc_prefix, **proj_kwargs)
             assert len(pr) == np.sum(eog_nums[::p_sl])
             write_proj(eog_proj, pr)
             projs.extend(pr)

--- a/mnefun/_ssp.py
+++ b/mnefun/_ssp.py
@@ -123,25 +123,18 @@ def _compute_erm_proj(p, subj, projs, kind, bad_file, remove_existing=False,
     flat = _handle_dict(p.flat, subj)
     raw = _raw_LRFCP(
         raw_names=empty_names, sfreq=p.proj_sfreq,
-        l_freq=p.erm_proj_hp_cut, h_freq=p.erm_proj_lp_cut,
+        l_freq=p.cont_hp, h_freq=p.cont_lp,
         n_jobs=p.n_jobs_fir, apply_proj=not remove_existing,
         n_jobs_resample=p.n_jobs_resample, projs=projs,
         bad_file=bad_file, disp_files=disp_files, method='fir',
         filter_length=p.filter_length, force_bads=True,
-        l_trans=p.hp_trans, h_trans=p.lp_trans,
+        l_trans=p.cont_hp_trans, h_trans=p.cont_lp_trans,
         phase=p.phase, fir_window=p.fir_window,
         skip_by_annotation='edge', **fir_kwargs)
     if remove_existing:
         raw.del_proj()
-    raw.filter(p.cont_hp, p.cont_lp, n_jobs=p.n_jobs_fir, method='fir',
-               filter_length=p.filter_length, h_trans_bandwidth=0.5,
-               fir_window=p.fir_window, phase=p.phase,
-               skip_by_annotation='edge', **fir_kwargs)
-    if projs:
-        raw.add_proj(projs)
-    raw.apply_proj()
     raw.pick_types(meg=True, eeg=False, exclude=())  # remove EEG
-    use_reject = p.erm_proj_reject
+    use_reject = p.cont_reject
     if use_reject is None:
         use_reject = p.reject
     use_reject, use_flat = _restrict_reject_flat(
@@ -326,7 +319,7 @@ def do_preprocessing_combined(p, subjects, run_indices):
         #
         # Calculate and apply ERM projectors
         #
-        if not p.erm_proj_as_esss:
+        if not p.cont_as_esss:
             if any(proj_nums[2]):
                 assert proj_nums[2][2] == 0  # no EEG projectors for ERM
                 if len(empty_names) == 0:

--- a/mnefun/_sss.py
+++ b/mnefun/_sss.py
@@ -414,7 +414,7 @@ def run_sss_locally(p, subjects, run_indices):
                   % (si + 1, len(subjects), subj))
         # compute eSSS basis
         kwargs = dict()
-        if p.erm_proj_as_esss:
+        if p.cont_as_esss:
             assert p.proj_meg == 'combined', 'must be combined for eSSS'
             proj_nums = _proj_nums(p, subj)[2]
             if any(proj_nums):

--- a/mnefun/data/canonical.yml
+++ b/mnefun/data/canonical.yml
@@ -57,6 +57,7 @@ preprocessing:
     cal_file:
     sss_format:
     mf_args:
+    erm_proj_as_esss:
   filtering:
     hp_cut:
     hp_trans:
@@ -73,6 +74,9 @@ preprocessing:
     auto_bad_eeg_thresh:
     auto_bad_meg_thresh:
     proj_nums:
+    erm_proj_hp_cut:
+    erm_proj_lp_cut:
+    erm_proj_reject:
     proj_sfreq:
     proj_meg:
     drop_thresh:

--- a/mnefun/data/canonical.yml
+++ b/mnefun/data/canonical.yml
@@ -57,7 +57,7 @@ preprocessing:
     cal_file:
     sss_format:
     mf_args:
-    erm_proj_as_esss:
+    cont_as_esss:
   filtering:
     hp_cut:
     hp_trans:
@@ -74,9 +74,6 @@ preprocessing:
     auto_bad_eeg_thresh:
     auto_bad_meg_thresh:
     proj_nums:
-    erm_proj_hp_cut:
-    erm_proj_lp_cut:
-    erm_proj_reject:
     proj_sfreq:
     proj_meg:
     drop_thresh:
@@ -102,7 +99,10 @@ preprocessing:
     proj_extra:
     get_projs_from:
     cont_hp:
+    cont_hp_trans:
     cont_lp:
+    cont_lp_trans:
+    cont_reject:
     plot_drop_logs:
 
 epoching:


### PR DESCRIPTION
Adds `eSSS` with optional band-pass support to `mnefun`. If `params.erm_proj_as_ess = True` then it will use `proj_nums[2]` for a given subject to compute empty-room projectors after band-pass filtering between `params.erm_proj_hp_cut` and `params.erm_proj_lp_cut`. You'll probably need to set `params.erm_proj_reject = {'mag': 5.e-11, 'grad': 1.5e-9}` or something similar since the empty-room data can be pretty noisy.

@NeuroLaunch @nordme @mdclarke (I can't remember who all had the issue) feel free to try this to see if it helps with any 30 Hz frequency bumps you see. I'm not 100% convinced that the bad channels are handled properly here, but basically it uses `raw_fif/subj_prebad.txt` to choose bad channels as these will be marked bad for *all* files that will be processed by SSS. So sometimes it might be important to make sure this is marked properly otherwise you might end up with a single channel dominating.

In any case, it doesn't seem to make a huge difference in the 30 Hz bump for the `funloc` data even with 8 projectors, but the bump wasn't huge there to begin with:

![Screenshot from 2020-12-18 15-45-39](https://user-images.githubusercontent.com/2365790/102660093-7b7a5e80-4148-11eb-8799-06be18024bc3.png)

It's possible there is some bug -- @NeuroLaunch please try it on some dataset with a prominent peak and see if it makes it at least go down a little bit. That would suggest it's at least implemented somewhat properly. And then you could compare re-running with `params.erm_proj_as_esss = False` just as a basis for comparison. For these comparisons I think you'll have to re-run from SSS, computing SSP, applying SSP, epoching, cov, inv, and reports. I will not have time to push fixes for a while so feel free to make a PR into my branch or start a new PR with my commits if you want.