### PR TITLE
FIX/ENH: Event picking for autoreject + epoching

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -491,6 +491,9 @@ autoreject_types : tuple
     reject trials on basis of EOG.
 reject_epochs_by_annot : bool
     If True, reject epochs by BAD annotations.
+pick_events_autoreject : callable | string | None
+    Function for picking covariance events, or the string "restrict"
+    to limit events to those with an id in ``in_numbers``.
 analyses : list of str
     Lists of analyses of interest.
 in_names : list of str
@@ -526,8 +529,9 @@ cov_method : str
 compute_rank : bool
     Default is False. Set to True to compute rank of the noise covariance
     matrix during inverse kernel computation.
-pick_events_cov : callable | None
-    Function for picking covariance events.
+pick_events_cov : callable | string | None
+    Function for picking covariance events, or the string "restrict"
+    to limit events to those with an id in ``in_numbers``.
 cov_rank : str | int
     Cov rank to use, usually "auto".
 cov_rank_method : str

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -492,7 +492,7 @@ autoreject_types : tuple
 reject_epochs_by_annot : bool
     If True, reject epochs by BAD annotations.
 pick_events_autoreject : callable | string | None
-    Function for picking covariance events, or the string "restrict"
+    Function for picking autoreject events, or the string "restrict"
     to limit events to those with an id in ``in_numbers``.
 analyses : list of str
     Lists of analyses of interest.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,6 +9,15 @@ master branch and often an up-to-date MNE-Python ``master`` branch.
 Changelog
 ~~~~~~~~~
 
+2021
+^^^^
+- 2021/02/18:
+    Expanded ``pick_events_cov`` and added ``pick_events_autoreject`` to
+    allow control over which events are chosen for the respective epoching
+    steps. In lieu of a function, the string "restrict" is acceptable to
+    choose event ids contained in ``in_numbers``. (Events for final epoching
+    are effectively selected with "restrict".)
+
 2020
 ^^^^
 - 2020/12/18:

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -144,7 +144,7 @@ def gen_covariances(p, subjects, run_indices, decim):
             this_decim = _handle_decim(decim[si], raw.info['sfreq'])
             # read in events
             picker = p.pick_events_cov
-            if type(picker) is str:
+            if isinstance(picker, str):
                 assert picker == 'restrict', \
                     'Only "restrict" is a valid string for p.pick_events_cov'
             elif picker and not callable(picker):

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -143,17 +143,13 @@ def gen_covariances(p, subjects, run_indices, decim):
             raw = concatenate_raws(raws)
             this_decim = _handle_decim(decim[si], raw.info['sfreq'])
             # read in events
-            events = _read_events(p, subj, ridx, raw)
-            if p.pick_events_cov is not None:
-                old_count = sum(len(e) for e in events)
-                if callable(p.pick_events_cov):
-                    picker = p.pick_events_cov
-                else:
-                    picker = p.pick_events_cov[ii]
-                events = picker(events)
-                new_count = len(events)
-                print('  Using %s/%s events for %s'
-                      % (new_count, old_count, op.basename(cov_name)))
+            picker = p.pick_events_cov  #SMB 2020-02-14
+            if type(picker) is str:
+                assert picker == 'restrict', \
+                    'Only "restrict" is a valid string for p.pick_events_cov'
+            elif picker and not callable(picker):
+                picker = picker[ii]
+            events = _read_events(p, subj, ridx, raw, picker=picker)
             # create epochs
             use_reject, use_flat = _restrict_reject_flat(reject, flat, raw)
             baseline = _get_baseline(p)

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -143,7 +143,7 @@ def gen_covariances(p, subjects, run_indices, decim):
             raw = concatenate_raws(raws)
             this_decim = _handle_decim(decim[si], raw.info['sfreq'])
             # read in events
-            picker = p.pick_events_cov  #SMB 2020-02-14
+            picker = p.pick_events_cov
             if type(picker) is str:
                 assert picker == 'restrict', \
                     'Only "restrict" is a valid string for p.pick_events_cov'

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -101,8 +101,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
         raw = [read_raw_fif(fname, preload=False) for fname in raw_names]
         _fix_raw_eog_cals(raw)  # EOG epoch scales might be bad!
         raw = concatenate_raws(raw)
-        # read in events
-        events = _read_events(p, subj, run_indices[si], raw)
+        # optionally calculate autoreject thresholds
         this_decim = _handle_decim(decim[si], raw.info['sfreq'])
         new_sfreq = raw.info['sfreq'] / this_decim
         if p.disp_files:
@@ -121,6 +120,11 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
             assert all(a in ('mag', 'grad', 'eeg', 'ecg', 'eog')
                        for a in p.autoreject_types)
             from autoreject import get_rejection_threshold
+            picker = p.pick_events_autoreject  #SMB 2020-02-14
+            if type(picker) is str:
+                assert picker == 'restrict', \
+                    'Only "restrict" is valid str for p.pick_events_autoreject'
+            events = _read_events(p, subj, run_indices[si], raw, picker=picker)
             print('    Computing autoreject thresholds', end='')
             rtmin = p.reject_tmin if p.reject_tmin is not None else p.tmin
             rtmax = p.reject_tmax if p.reject_tmax is not None else p.tmax
@@ -146,7 +150,8 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
             write_hdf5(hdf5_file, use_reject, overwrite=True)
         else:
             use_reject = _handle_dict(p.reject, subj)
-        # create epochs
+        # read in events and create epochs
+        events = _read_events(p, subj, run_indices[si], raw, picker='restrict')
         flat = _handle_dict(p.flat, subj)
         use_reject, use_flat = _restrict_reject_flat(use_reject, flat, raw)
         epochs = Epochs(raw, events, event_id=old_dict, tmin=p.tmin,

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -120,7 +120,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
             assert all(a in ('mag', 'grad', 'eeg', 'ecg', 'eog')
                        for a in p.autoreject_types)
             from autoreject import get_rejection_threshold
-            picker = p.pick_events_autoreject  #SMB 2020-02-14
+            picker = p.pick_events_autoreject
             if type(picker) is str:
                 assert picker == 'restrict', \
                     'Only "restrict" is valid str for p.pick_events_autoreject'

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -192,7 +192,7 @@ class Params(Frozen):
         # Use more than EXTRA points to fit headshape
         self.dig_with_eeg = False
         # Function to pick a subset of events to use to make a covariance
-        self.pick_events_cov = None
+        self.pick_events_cov = None  # or string 'restrict'
         self.cov_method = cov_method
         self.proj_extra = None
         # These should be overridden by the user unless they are only doing
@@ -219,6 +219,7 @@ class Params(Frozen):
         self.subject_run_indices = None
         self.autoreject_thresholds = False
         self.autoreject_types = ['mag', 'grad', 'eeg']
+        self.pick_events_autoreject = None  # similar to .pick_events_cov
         self.subjects_dir = None
         self.src_pos = 7.
         self.report_params = dict(

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -5,7 +5,6 @@
 import warnings
 
 import numpy as np
-import os.path as op
 from mne import find_events, write_events, read_events, concatenate_events
 from mne.io import read_raw_fif
 
@@ -104,16 +103,18 @@ def extract_expyfun_events(fname, return_offsets=False):
     these_events[:, 2] = event_nums
     return these_events, resps, orig_events
 
-def _pick_events(events, picker):    #SMB 2020-02-14
+
+def _pick_events(events, picker):
     old_cnt = sum(len(e) for e in events)
     events = picker(events)
     new_cnt = len(events)
     print(f'  Using {new_cnt}/{old_cnt} events.')
 
+
 def _read_events(p, subj, ridx, raw, picker=None):
     ridx = np.array(ridx)
     assert ridx.ndim == 1
-    if picker=='restrict':  # events that will be processed
+    if picker == 'restrict':  # limit to events that will be processed
         ids = p.in_numbers
         picker = None
         print('Events restricted to those in params.in_numbers')
@@ -132,7 +133,7 @@ def _read_events(p, subj, ridx, raw, picker=None):
     else:
         first_samps = raw._first_samps
         last_samps = raw._last_samps
-    events = concatenate_events(events, first_samps, last_samps)  #repeats ok?
+    events = concatenate_events(events, first_samps, last_samps)
     if picker:
         events = _pick_events(events, picker)
     if len(np.unique(events[:, 0])) != len(events):

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -123,9 +123,6 @@ def _read_events(p, subj, ridx, raw, picker=None):
     events = list()
     for fname in get_event_fnames(p, subj, ridx):
         these_events = read_events(fname, include=ids)
-        # if len(np.unique(these_events[:, 0])) != len(these_events):
-        #     raise RuntimeError('Non-unique event samples found in %s'
-        #                        % (fname,))
         events.append(these_events)
     if len(events) == 1 and len(raw._first_samps) > 1:  # for split raw
         first_samps = raw._first_samps[:1]

--- a/mnefun/_yaml.py
+++ b/mnefun/_yaml.py
@@ -142,7 +142,7 @@ def _flatten_dicts(d, out, keys_to_flatten):
         if key in keys_to_flatten:
             _flatten_dicts(val, out, keys_to_flatten)
         else:
-            assert key not in out
+            assert key not in out, f'parameter {key} may be repeated'
             out[key] = val
 
 

--- a/mnefun/data/canonical.yml
+++ b/mnefun/data/canonical.yml
@@ -123,6 +123,7 @@ epoching:
   autoreject_thresholds:
   autoreject_types:
   reject_epochs_by_annot:
+  pick_events_autoreject:
   analyses:
   in_names:
   in_numbers:


### PR DESCRIPTION
Fixes #319 

Partly this PR fixes an error in _\_scoring.py:\_read_events()_ when two events of different ids have the same timestamp.  The simplest workaround would be to pull in only the events that are to be later processed.  At the suggestion of @larsoner I retained existing code for picking events for covariance estimation via a user-defined function, and ported a similar step for the auto_rejection step.  For convenience (e.g. to overcome the double-timestamp issue), the string "restrict" can be used instead of the user-defined picking function; this is interpreted simply as using the events already chosen for processing via `params.in_numbers`.  After the picking, an error is given if repeated timestamps are found.

I think this method gives the most flexibility for choosing events for epoching, depending on how those epochs will be used, whether it's for calculating covariance or rejection thresholds.  Note that an extra event reading step was added for the _final_ epoching (i.e. for epochs that will be written to disk); in this case the "restrict" option is used because only and all events marked for analysis should be included at this step.  (The "restrict" option should work even if `params.in_numbers` is `None`, because then `include=None` when executing _mne.read\_events()_.)

One potential point of failure is that, within _\_read_events()_, repeated timestamps are checked only _after_ events are concatenated across files. I had no practical way to check this situation (I left in the original code, commented out).


