### PR TITLE
BUG: Handle additional entries

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -107,7 +107,7 @@ acq_exclude : list of str
         ['genz_proc', 'genz_[0-9]+_[0-9]+a']
 
     which means "exclude anything with 'genz_proc'; or anything starting with
-    'genz_', followed by at least one number, followed by '_', folwwed by at
+    'genz\_', followed by at least one number, followed by '_', folwwed by at
     least one number, followed by 'a'" -- the latter being useful when subjects
     should be named ``genz100_9a`` but have some duplicate directories named
     ``genz_100_9a``.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -98,6 +98,10 @@ acq_dir : list of str
     List of paths to search and fetch raw data.
 acq_port : int
     Acquisition port.
+acq_exclude : list of str
+    Names to exclude when trying to find the correct remote directory. This can
+    be useful for example if a subject was run more than once, or someone has
+    done some preprocessing or made copies on the acquisition machine.
 run_names : list of str
     Run names for the paradigm.
 runs_empty : list of str

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -106,11 +106,11 @@ run_names : list of str
     Run names for the paradigm.
 runs_empty : list of str
     Empty room run names.
-subject_run_indices : list of array-like | None
+subject_run_indices : list of array-like | dict | None
     Run indices to include for each subject. This can be a list
     (must be same length as ``params.subjects``) or a dict (keys are subject
-    strings, values are the run indices) including a defaultdict. None is an
-    alias for "all runs".
+    strings, values are the run indices) where missing subjects get all runs.
+    None is an alias for "all runs".
 
 2. do_score
 -----------

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -106,11 +106,11 @@ acq_exclude : list of str
 
         ['genz_proc', 'genz_[0-9]+_[0-9]+a']
 
-    which means "exclude anything with 'genz_proc'; or anything starting with
-    'genz\_', followed by at least one number, followed by '_', folwwed by at
-    least one number, followed by 'a'" -- the latter being useful when subjects
-    should be named ``genz100_9a`` but have some duplicate directories named
-    ``genz_100_9a``.
+    which means "exclude anything with 'genz_proc'; or anything with a
+    substring that has 'genz\_', followed by at least one number, followed by
+    '_', followed by at least one number, followed by 'a'" -- the latter being
+    useful when subjects should be named ``genz100_9a`` but have some duplicate
+    directories named ``genz_100_9a``.
 run_names : list of str
     Run names for the paradigm.
 runs_empty : list of str

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -99,9 +99,18 @@ acq_dir : list of str
 acq_port : int
     Acquisition port.
 acq_exclude : list of str
-    Names to exclude when trying to find the correct remote directory. This can
-    be useful for example if a subject was run more than once, or someone has
-    done some preprocessing or made copies on the acquisition machine.
+    Regular expressions to exclude when trying to find the correct remote
+    directory. This can be useful for example if a subject was run more than
+    once, or someone has done some preprocessing or made copies on the
+    acquisition machine, e.g.::
+
+        ['genz_proc', 'genz_[0-9]+_[0-9]+a']
+
+    which means "exclude anything with 'genz_proc'; or anything starting with
+    'genz_', followed by at least one number, followed by '_', folwwed by at
+    least one number, followed by 'a'" -- the latter being useful when subjects
+    should be named ``genz100_9a`` but have some duplicate directories named
+    ``genz_100_9a``.
 run_names : list of str
     Run names for the paradigm.
 runs_empty : list of str

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ Changelog
 
 2021
 ^^^^
+- 2021/02/23:
+    - Added ``acq_exclude`` to allow excluding folder names when searching for
+      files on a remote acquisition machine.
+    - Modified ``fetch_raw=True`` functionality to be more friendly to data
+      being transferred to NFS mounts by not trying to set as many permissions.
 - 2021/02/18:
     Expanded ``pick_events_cov`` and added ``pick_events_autoreject`` to
     allow control over which events are chosen for the respective epoching

--- a/mnefun/_fetching.py
+++ b/mnefun/_fetching.py
@@ -82,9 +82,11 @@ def fetch_raw_files(p, subjects, run_indices):
         run_subprocess(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # move files to root raw_dir
         for fname in remote_fnames:
-            from_ = fname.index(subj)
-            shutil.move(op.join(raw_dir, fname[from_:].lstrip('/')),
-                        op.join(raw_dir, op.basename(fname)))
+            from_ = fname[fname.index(subj):].lstrip('/')
+            to_ = op.basename(fname)
+            if from_ != to_:  # can happen if it's at the root
+                shutil.move(op.join(raw_dir, from_),
+                            op.join(raw_dir, to_))
         # prune the extra directories we made
         for fname in remote_fnames:
             from_ = fname.index(subj)

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -202,6 +202,7 @@ class Params(Frozen):
         self.dates = None
         self.score = None  # defaults to passing events through
         self.acq_ssh = self.acq_dir = None
+        self.acq_exclude = []
         self.acq_port = 22
         self.sws_ssh = self.sws_dir = None
         self.sws_port = 22

--- a/mnefun/_mnefun.py
+++ b/mnefun/_mnefun.py
@@ -496,7 +496,7 @@ def do_processing(p, fetch_raw=False, do_score=False, push_raw=False,
     if run_indices is None:
         run_indices = [None] * len(subjects)
     elif isinstance(run_indices, dict):
-        run_indices = [run_indices[subject] for subject in subjects]
+        run_indices = [run_indices.get(subject, None) for subject in subjects]
     else:
         run_indices = [run_indices[si] for si in sinds]
         assert len(run_indices) == len(subjects)

--- a/mnefun/_paths.py
+++ b/mnefun/_paths.py
@@ -68,7 +68,7 @@ def get_event_fnames(p, subj, run_indices=None):
 
 def _regex_convert(f):
     """Regex a given filename (for split file purposes)."""
-    return '.*%s-?[0-9]*.fif$' % op.basename(f)[:-4]
+    return '.*%s-?[0-9]*.fif$' % op.splitext(op.basename(f))[0]
 
 
 def get_raw_fnames(p, subj, which='raw', erm=True, add_splits=False,

--- a/mnefun/_scoring.py
+++ b/mnefun/_scoring.py
@@ -109,6 +109,7 @@ def _pick_events(events, picker):
     events = picker(events)
     new_cnt = len(events)
     print(f'  Using {new_cnt}/{old_cnt} events.')
+    return events
 
 
 def _read_events(p, subj, ridx, raw, picker=None):
@@ -117,12 +118,18 @@ def _read_events(p, subj, ridx, raw, picker=None):
     if picker == 'restrict':  # limit to events that will be processed
         ids = p.in_numbers
         picker = None
-        print('Events restricted to those in params.in_numbers')
+        print('    Events restricted to those in params.in_numbers')
     else:
         ids = None
     events = list()
     for fname in get_event_fnames(p, subj, ridx):
-        these_events = read_events(fname, include=ids)
+        # gracefully handle empty events (e.g., resting state)
+        with open(fname, 'r') as fid:
+            content = fid.read().strip()
+        if not content:
+            these_events = np.empty((0, 3), int)
+        else:
+            these_events = read_events(fname, include=ids)
         events.append(these_events)
     if len(events) == 1 and len(raw._first_samps) > 1:  # for split raw
         first_samps = raw._first_samps[:1]

--- a/mnefun/data/canonical.yml
+++ b/mnefun/data/canonical.yml
@@ -11,6 +11,7 @@ fetch_raw:
   acq_ssh:
   acq_dir:
   acq_port:
+  acq_exclude:
   run_names:
   runs_empty:
   subject_run_indices:


### PR DESCRIPTION
1. If there are multiple sets of files discovered, it's a problem for `fetch_raw=True`. I am hitting this with GenZ for example where some preprocessing was done in the same folder as the acquisition files on `brainstudio`, which means two sets of "original" `_raw.fif` files are found. This adds an `acq_exclude` that allows a list of substrings to look for to exclude. In principle this might also help if a subject is run twice on a given experiment -- you can exclude their unused/old acquisition by folder name (run date) for example.
2. Tweaks the `rsync` command to be NFS-friendly by not trying to set folder mtime and by not being strict about permissions set on the transferred files.