### PR TITLE
Fix: use reject by annot regex during cov step

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ copyright = u'2013-{0}, mnefun Developers'.format(date.today().year)
 version = mnefun.__version__
 release = version
 exclude_trees = ['_build']
-default_role = 'autolink'
+default_role = 'py:obj'
 pygments_style = 'manni'
 modindex_common_prefix = ['mnefun.']
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -140,7 +140,7 @@ on_process : callable
 
 .. warning:: Before running SSS, set ``params.mf_prebad[SUBJ]`` to a
              list of bad MEG channels (str), or (old way) create
-             `SUBJ/raw_fif/SUBJ_prebad.txt`` with space-separated list of bad
+             ``SUBJ/raw_fif/SUBJ_prebad.txt`` with space-separated list of bad
              MEG channel numbers (int).
              Using ``p.mf_autobad=True`` can help fill in missed bad channels,
              but is not as reliable as experienced analyst inspection.
@@ -720,7 +720,7 @@ Preparing your machine for MaxFilter use
              deprecated.
 
 Parameters for remotely connecting to SSS workstation ('sws') can be set
-by adding a file `~/.mnefun/mnefun.json` with contents like:
+by adding a file :file:`~/.mnefun/mnefun.json` with contents like:
 
 .. code-block:: console
 

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -141,6 +141,8 @@ def gen_covariances(p, subjects, run_indices, decim):
             elif picker and not callable(picker):
                 picker = picker[ii]
             events = _read_events(p, subj, ridx, raw, ratios, picker=picker)
+            # handle regex-based reject_epochs_by_annot defs
+            reject_epochs_by_annot = _check_reject_annot_regex(p, raw)
             # create epochs
             use_reject, use_flat = _restrict_reject_flat(reject, flat, raw)
             baseline = _get_baseline(p)
@@ -151,7 +153,7 @@ def gen_covariances(p, subjects, run_indices, decim):
                             decim=this_decim,
                             verbose='error',  # ignore decim-related warnings
                             on_missing=p.on_missing,
-                            reject_by_annotation=p.reject_epochs_by_annot)
+                            reject_by_annotation=reject_epochs_by_annot)
             epochs.pick_types(meg=True, eeg=True, exclude=[])
             cov = compute_covariance(epochs, method=p.cov_method,
                                      **kwargs)

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -17,7 +17,7 @@ from ._epoching import _concat_resamp_raws
 from ._paths import get_epochs_evokeds_fnames, get_raw_fnames, safe_inserter
 from ._scoring import _read_events
 from ._utils import (get_args, _get_baseline, _restrict_reject_flat,
-                     _handle_dict, _handle_decim)
+                     _handle_dict, _handle_decim, _check_reject_annot_regex)
 
 
 def _compute_rank(p, subj, run_indices):

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -1,6 +1,5 @@
 import os
 import os.path as op
-import re
 import warnings
 
 import numpy as np
@@ -17,7 +16,8 @@ from ._paths import get_raw_fnames, get_epochs_evokeds_fnames
 from ._scoring import _read_events
 from ._sss import _read_raw_prebad
 from ._utils import (_fix_raw_eog_cals, _get_baseline, get_args, _handle_dict,
-                     _restrict_reject_flat, _get_epo_kwargs, _handle_decim)
+                     _restrict_reject_flat, _get_epo_kwargs, _handle_decim,
+                     _check_reject_annot_regex)
 
 
 def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
@@ -111,23 +111,8 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
         epochs_fnames, evoked_fnames = get_epochs_evokeds_fnames(p, subj,
                                                                  analyses)
         mat_file, fif_file = epochs_fnames
-        if isinstance(p.reject_epochs_by_annot, str):
-            reject_epochs_by_annot = True
-            reg = re.compile(p.reject_epochs_by_annot)
-            n_orig = sum(desc.lower().startswith('bad_')
-                         for desc in raw.annotations.description)
-            mask = np.array([reg.match(desc) is not None
-                             for desc in raw.annotations.description], bool)
-            print(f'      Rejecting epochs with via {mask.sum()}  '
-                  'annotation(s) via regex matching '
-                  f'({n_orig} originally were BAD_ type)')
-            # remove the unwanted ones
-            raw.annotations.delete(np.where(~mask)[0])
-            for ii in range(len(raw.annotations)):
-                raw.annotations.description[ii] = 'BAD_REGEX'
-        else:
-            assert isinstance(p.reject_epochs_by_annot, bool)
-            reject_epochs_by_annot = p.reject_epochs_by_annot
+        # handle regex-based reject_epochs_by_annot defs
+        reject_epochs_by_annot = _check_reject_annot_regex(p, raw)
         if p.autoreject_thresholds:
             assert len(p.autoreject_types) > 0
             assert all(a in ('mag', 'grad', 'eeg', 'ecg', 'eog')


### PR DESCRIPTION
allows regex-based `reject_epochs_by_annot` when epoching during covariance computation