### PR TITLE
suppress plots during _raise_bad_epochs

### DIFF
--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -180,7 +180,7 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
                         reject_tmin=p.reject_tmin, reject_tmax=p.reject_tmax,
                         reject_by_annotation=reject_epochs_by_annot)
         if epochs.events.shape[0] < 1:
-            _raise_bad_epochs(raw, epochs, events)
+            _raise_bad_epochs(raw, epochs, events, plot=p.plot_drop_logs)
         del raw
         drop_logs.append(epochs.drop_log)
         ch_namess.append(epochs.ch_names)
@@ -343,9 +343,10 @@ def _concat_resamp_raws(p, subj, fnames, fix='EOG', prebad=False,
     return raw, ratios
 
 
-def _raise_bad_epochs(raw, epochs, events, kind=None):
+def _raise_bad_epochs(raw, epochs, events, kind=None, plot=True):
     extra = '' if kind is None else f' of type {kind} '
-    plot_drop_log(epochs.drop_log)
-    raw.plot(events=events)
+    if plot:
+        plot_drop_log(epochs.drop_log)
+        raw.plot(events=events)
     raise RuntimeError(
         f'Only {len(epochs)}/{len(events)} good epochs found{extra}')

--- a/mnefun/_ssp.py
+++ b/mnefun/_ssp.py
@@ -159,7 +159,8 @@ def _compute_erm_proj(p, subj, projs, kind, bad_file, remove_existing=False,
         _raise_bad_epochs(
             raw, epochs, events,
             f'1-sec empty room via {reject_kind} = {use_reject} (consider '
-            f'changing p.cont_reject)')
+            f'changing p.cont_reject)',
+            plot=p.plot_drop_logs)
     assert len(pr) == np.sum(proj_nums[2][::p_sl])
     # When doing eSSS it's a bit weird to put this in pca_dir but why not
     pca_dir = _get_pca_dir(p, subj)
@@ -396,7 +397,8 @@ def do_preprocessing_combined(p, subjects, run_indices):
                 write_proj(ecg_proj, pr)
                 projs.extend(pr)
             else:
-                _raise_bad_epochs(raw, ecg_epochs, ecg_events, 'ECG')
+                _raise_bad_epochs(raw, ecg_epochs, ecg_events, 'ECG',
+                                  plot=p.plot_drop_logs)
             del raw, ecg_epochs, ecg_events
         else:
             _safe_remove([ecg_proj, ecg_eve, ecg_epo])


### PR DESCRIPTION
helpful when running on a headless server...  currently things hang with a `qt.qpa.xcb: QXcbConnection: XCB error: 128 (Unknown), sequence: 417, resource id: 0, major code: 131 (Unknown), minor code: 2` and the `RuntimeError` with the helpful message never appears.