### PR TITLE
use delayed proj when epoching during cov computation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,7 +12,7 @@ Changelog
 2021
 ^^^^
 - 2021/07/29:
-    Change ``proj=True`` to ``proj='delayed'`` when epoching during covariance
+    Change ``proj=False`` to ``proj='delayed'`` when epoching during covariance
     computation, to accord with the fact that the rejection thresholds may have
     been determined from projected data.
 - 2021/05/03:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,10 @@ Changelog
 
 2021
 ^^^^
+- 2021/07/29:
+    Change ``proj=True`` to ``proj='delayed'`` when epoching during covariance
+    computation, to accord with the fact that the rejection thresholds may have
+    been determined from projected data.
 - 2021/05/03:
     Add support for returning ``None`` from ``p.match_fun`` to use default
     scoring, and allowing ``numbers`` to be passed to ``p.match_fun``.

--- a/mnefun/_cov.py
+++ b/mnefun/_cov.py
@@ -148,7 +148,7 @@ def gen_covariances(p, subjects, run_indices, decim):
             baseline = _get_baseline(p)
             epochs = Epochs(raw, events, event_id=None, tmin=p.bmin,
                             tmax=p.bmax, baseline=baseline,
-                            proj=False,
+                            proj='delayed',
                             reject=use_reject, flat=use_flat, preload=True,
                             decim=this_decim,
                             verbose='error',  # ignore decim-related warnings


### PR DESCRIPTION
closes #349 

Waiting for confirmation from @larsoner that this is the right fix, but it's an easy enough fix that I figured I'd tee it up anyway just in case.