### PR TITLE
_concat_resamp_raws fix

### DIFF
--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -302,7 +302,7 @@ def _concat_resamp_raws(p, subj, fnames, fix='EOG', prebad=False,
         raws.append(raw)
         first_samps.append(raw._first_samps[0])
         last_samps.append(raw._last_samps[-1])
-        fixed_dht = raw.info['dev_head_t'] if ri==0 else fixed_dht
+        fixed_dht = raw.info['dev_head_t'] if ri == 0 else fixed_dht
         if set_dev_head_t:
             raw.info['dev_head_t'] = fixed_dht
         del raw

--- a/mnefun/_epoching.py
+++ b/mnefun/_epoching.py
@@ -288,11 +288,12 @@ def save_epochs(p, subjects, in_names, in_numbers, analyses, out_names,
 
 
 def _concat_resamp_raws(p, subj, fnames, fix='EOG', prebad=False,
-                        preload=None):
+                        preload=None, set_dev_head_t=False):
     raws = []
     first_samps = []
     last_samps = []
-    for raw_fname in fnames:
+    fixed_dht = 0
+    for ri, raw_fname in enumerate(fnames):
         if prebad:
             raw = _read_raw_prebad(p, subj, raw_fname, False)
         else:
@@ -301,6 +302,9 @@ def _concat_resamp_raws(p, subj, fnames, fix='EOG', prebad=False,
         raws.append(raw)
         first_samps.append(raw._first_samps[0])
         last_samps.append(raw._last_samps[-1])
+        fixed_dht = raw.info['dev_head_t'] if ri==0 else fixed_dht
+        if set_dev_head_t:
+            raw.info['dev_head_t'] = fixed_dht
         del raw
     assert len(raws) > 0
     rates = np.array([r.info['sfreq'] for r in raws], float)

--- a/mnefun/_report.py
+++ b/mnefun/_report.py
@@ -355,7 +355,8 @@ def gen_html_report(p, subjects, structurals, run_indices=None):
                 raise RuntimeError('Cannot create reports until raw data '
                                    'exist, missing:\n%s' % fname)
         raw, _ = _concat_resamp_raws(
-            p, subj, fnames, fix='all', prebad=True, preload=preload)
+            p, subj, fnames, fix='all', prebad=True, preload=preload,
+            set_dev_head_t=True)
 
         # sss
         sss_fnames = get_raw_fnames(p, subj, 'sss', False, False,


### PR DESCRIPTION
mnefun/_reports began throwing an error when trying to concatenate raw files for the purpose of plots such as the raw segments and raw psd plots. Apparently, mne's raw.info checking before concatenation has become more stringent. 

This PR adds an argument to the `_concat_resamp_raws` function called `set_dev_head_t`. Default is `False`, but if `True`, `raw.info['dev_head_t']` from the first raw is used for all subsequent raws. 

@larsoner This is working well for the data I've tested it on (the new Genz data). 