### PR TITLE
fix except -> else when importing for mark_flat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: sudo apt update && sudo apt install graphviz-dev graphviz
       - run: python -m pip install --quiet --upgrade --user pip
-      - run: python -m pip install --quiet --upgrade --user numpy scipy https://github.com/mne-tools/mne-python/zipball/main numpydoc sphinx sphinx_fontawesome sphinx_bootstrap_theme pygraphviz
+      - run: python -m pip install --quiet --upgrade --user numpy scipy git+https://github.com/mne-tools/mne-python@main numpydoc sphinx sphinx_fontawesome sphinx_bootstrap_theme pygraphviz
       - run: python -c "import mne; mne.sys_info()"
       - run: python setup.py develop --user
       - run: cd doc && make html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - run: |
           pip install --upgrade --only-binary=":all:" pip setuptools wheel
           pip install --upgrade --only-binary=":all:" numpy scipy matplotlib h5io
-          pip install --upgrade pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc https://github.com/mne-tools/mne-python/zipball/main
+          pip install --upgrade pyyaml patsy pytest pytest-cov codecov flake8 pydocstyle numpydoc git+https://github.com/mne-tools/mne-python@main
         name: Install
       - run: make flake
       - run: pytest mnefun

--- a/mnefun/_sss.py
+++ b/mnefun/_sss.py
@@ -50,7 +50,7 @@ except ImportError:
             raw.set_annotations(raw.annotations + annot)
             raw.info['bads'] += bads
             return raw
-except ImportError:
+else:
     def mark_flat(raw, bad_percent=5., min_duration=0.005, picks=None,
                   verbose=None):
         annot, bads = annotate_amplitude(


### PR DESCRIPTION
Today I hit
```
NameError: name 'mark_flat' is not defined
> /opt/mne/fun/mnefun/_sss.py(689)_python_autobad()
    687     del skip_stop, skip_start
    688     picks_meg = pick_types(raw.info, meg=True)
--> 689     mark_flat(raw, picks=picks_meg, verbose=False)
```

because `try: mne.preprocessing.annotate_amplitude` succeeded, but then it was never used in defining `mark_flat` because the `else` clause was wrongly coded as an `except` clause.